### PR TITLE
[web] Add aerial_robot_web console

### DIFF
--- a/aerial_robot_web/CMakeLists.txt
+++ b/aerial_robot_web/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(aerial_robot_web)
+
+find_package(catkin REQUIRED COMPONENTS rospy)
+
+catkin_package()
+
+catkin_install_python(PROGRAMS
+  scripts/aerial_robot_web_server.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(FILES README.md
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+install(DIRECTORY launch www
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  USE_SOURCE_PERMISSIONS
+)

--- a/aerial_robot_web/README.md
+++ b/aerial_robot_web/README.md
@@ -1,0 +1,41 @@
+# aerial_robot_web
+
+`aerial_robot_web` is a mobile-first ROS web console shared by all aerial robot bringup launches.
+It serves a static React single-page application and starts `rosbridge_server` so phones, tablets,
+or a laptop browser can inspect the ROS graph without RViz/rqt.
+
+## Launch
+
+Each robot `bringup.launch` includes this package by default and prints a URL similar to:
+
+```text
+Aerial Robot Web Console ready: http://localhost:8080?robot_ns=hydrus&robot_type=hydrus&rosbridge_port=9090
+```
+
+The console can also be launched directly:
+
+```bash
+roslaunch aerial_robot_web web_console.launch robot_ns:=hydrus robot_type:=hydrus
+```
+
+Useful arguments:
+
+- `web_port` (default: `8080`) changes the HTTP port.
+- `rosbridge_port` (default: `9090`) changes the websocket port.
+- `launch_rosbridge` (default: `true`) can be disabled when another rosbridge is already running.
+
+## Features
+
+- Live node/topic lists using `rosapi`, with case-insensitive filtering.
+- Per-node publications, subscriptions, and services.
+- Per-topic type, publishers, subscribers, and a throttled live message preview.
+- Touch-friendly URDF viewer that mirrors live `/joint_states`, reframes the camera once
+  meshes finish loading, and reports mesh load failures.
+- `package://` mesh resources are served by the console HTTP server under `/pkg/<package>/<path>`.
+- Automatic rosbridge reconnection every few seconds after a dropped or failed connection.
+
+## Limitations
+
+- React, roslib, and Three.js are loaded from a CDN, so the browser needs internet access at
+  least once to cache them. On a fully offline robot LAN the console shows a static notice
+  instead of the interface.

--- a/aerial_robot_web/launch/web_console.launch
+++ b/aerial_robot_web/launch/web_console.launch
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="robot_ns" default="" />
+  <arg name="robot_type" default="generic" />
+  <arg name="web_port" default="8080" />
+  <arg name="rosbridge_port" default="9090" />
+  <arg name="launch_rosbridge" default="true" />
+
+  <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch" if="$(arg launch_rosbridge)">
+    <arg name="port" value="$(arg rosbridge_port)" />
+  </include>
+
+  <node pkg="aerial_robot_web"
+        type="aerial_robot_web_server.py"
+        name="aerial_robot_web_server"
+        output="screen">
+    <param name="port" value="$(arg web_port)" />
+    <param name="rosbridge_port" value="$(arg rosbridge_port)" />
+    <param name="robot_ns" value="$(arg robot_ns)" />
+    <param name="robot_type" value="$(arg robot_type)" />
+  </node>
+</launch>

--- a/aerial_robot_web/package.xml
+++ b/aerial_robot_web/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>aerial_robot_web</name>
+  <version>0.1.0</version>
+  <description>Mobile friendly web console for inspecting ROS graph state and debugging aerial robot joints.</description>
+
+  <maintainer email="oku@dragon.t.u-tokyo.ac.jp">Tomoya Oku</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>rospy</build_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rosbridge_server</exec_depend>
+  <exec_depend>rosapi</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>python3-rospkg</exec_depend>
+
+  <export/>
+</package>

--- a/aerial_robot_web/scripts/aerial_robot_web_server.py
+++ b/aerial_robot_web/scripts/aerial_robot_web_server.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Serve the aerial robot web console as a ROS node."""
+
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+import os
+import posixpath
+import socket
+import threading
+from urllib.parse import unquote, urlparse
+
+import rospy
+import rospkg
+
+
+ROSPACK = rospkg.RosPack()
+
+
+def resolve_package_resource(url_path):
+    """Map /pkg/<package>/<relpath> to a file inside the package share directory.
+
+    Returns None when the package is unknown or the path escapes the package.
+    """
+    parts = [unquote(part) for part in posixpath.normpath(url_path).split("/") if part]
+    if len(parts) < 3 or parts[0] != "pkg":
+        return None
+    try:
+        package_root = os.path.realpath(ROSPACK.get_path(parts[1]))
+    except rospkg.ResourceNotFound:
+        return None
+    candidate = os.path.realpath(os.path.join(package_root, *parts[2:]))
+    if candidate != package_root and not candidate.startswith(package_root + os.sep):
+        return None
+    return candidate
+
+
+class ConsoleHandler(SimpleHTTPRequestHandler):
+    """Static file handler with SPA fallback and package:// mesh serving."""
+
+    def end_headers(self):
+        if self.path.startswith("/pkg/"):
+            self.send_header("Cache-Control", "max-age=3600")
+        else:
+            self.send_header("Cache-Control", "no-store")
+        super().end_headers()
+
+    def log_message(self, fmt, *args):
+        rospy.logdebug("web console: " + fmt, *args)
+
+    def translate_path(self, path):
+        url_path = urlparse(path).path
+        if url_path.startswith("/pkg/"):
+            resolved = resolve_package_resource(url_path)
+            if resolved:
+                return resolved
+            # Force a 404 instead of falling back to the SPA page.
+            return os.path.join(self.directory, "pkg-not-found")
+        return super().translate_path(path)
+
+    def send_head(self):
+        path = urlparse(self.path).path
+        if path not in ("/", "/index.html") and not path.startswith("/pkg/"):
+            candidate = os.path.join(self.directory, path.lstrip("/"))
+            # Only application routes (no file extension) fall back to the SPA
+            # page; missing assets must return 404 so loaders can detect them.
+            if not os.path.exists(candidate) and "." not in posixpath.basename(path):
+                self.path = "/index.html"
+        return super().send_head()
+
+
+def get_host_label(configured_host):
+    if configured_host not in ("", "0.0.0.0", "::"):
+        return configured_host
+    try:
+        return socket.gethostname() or "localhost"
+    except socket.error:
+        return "localhost"
+
+
+def main():
+    rospy.init_node("aerial_robot_web_server")
+    host = rospy.get_param("~host", "")
+    port = int(rospy.get_param("~port", 8080))
+    rosbridge_port = int(rospy.get_param("~rosbridge_port", 9090))
+    robot_ns = rospy.get_param("~robot_ns", "")
+    robot_type = rospy.get_param("~robot_type", "generic")
+    package_path = ROSPACK.get_path("aerial_robot_web")
+    web_root = rospy.get_param("~web_root", os.path.join(package_path, "www"))
+
+    handler = partial(ConsoleHandler, directory=web_root)
+    bind_host = "" if host in ("0.0.0.0", "::") else host
+    httpd = ThreadingHTTPServer((bind_host, port), handler)
+    thread = threading.Thread(target=httpd.serve_forever)
+    thread.daemon = True
+    thread.start()
+
+    query = "?robot_ns={}&robot_type={}&rosbridge_port={}".format(robot_ns, robot_type, rosbridge_port)
+    localhost_url = "http://localhost:{}{}".format(port, query)
+    host_url = "http://{}:{}{}".format(get_host_label(host), port, query)
+    rospy.loginfo("Aerial Robot Web Console ready: %s", localhost_url)
+    rospy.loginfo("Aerial Robot Web Console LAN hint: %s", host_url)
+
+    rospy.on_shutdown(httpd.shutdown)
+    rospy.spin()
+
+
+if __name__ == "__main__":
+    main()

--- a/aerial_robot_web/www/app.js
+++ b/aerial_robot_web/www/app.js
@@ -1,0 +1,295 @@
+(() => {
+  const e = React.createElement;
+  const params = new URLSearchParams(window.location.search);
+  const defaultBridgePort = params.get('rosbridge_port') || '9090';
+  const initialRobotNs = normalizeNs(params.get('robot_ns') || '');
+  const robotType = params.get('robot_type') || 'generic';
+  const RECONNECT_DELAY_MS = 3000;
+  const PREVIEW_THROTTLE_MS = 500;
+  const PREVIEW_MAX_CHARS = 4000;
+
+  function normalizeNs(ns) {
+    if (!ns) return '';
+    return ns.startsWith('/') ? ns : `/${ns}`;
+  }
+
+  function serviceName(name) {
+    return name.startsWith('/') ? name : `/${name}`;
+  }
+
+  function useRosConnection(url) {
+    const [attempt, setAttempt] = React.useState(0);
+    const [state, setState] = React.useState({ connected: false, error: '', ros: null });
+    React.useEffect(() => {
+      let alive = true;
+      let retryId = 0;
+      const ros = new ROSLIB.Ros({ url });
+      const scheduleRetry = () => {
+        window.clearTimeout(retryId);
+        retryId = window.setTimeout(() => setAttempt((value) => value + 1), RECONNECT_DELAY_MS);
+      };
+      ros.on('connection', () => alive && setState({ connected: true, error: '', ros }));
+      ros.on('close', () => {
+        if (!alive) return;
+        setState((prev) => ({ ...prev, connected: false }));
+        scheduleRetry();
+      });
+      ros.on('error', (error) => {
+        if (!alive) return;
+        setState({ connected: false, error: String(error?.message || error || 'connection error'), ros });
+      });
+      return () => {
+        alive = false;
+        window.clearTimeout(retryId);
+        ros.close();
+      };
+    }, [url, attempt]);
+    return state;
+  }
+
+  function callService(ros, name, type, values = {}) {
+    return new Promise((resolve, reject) => {
+      const service = new ROSLIB.Service({ ros, name: serviceName(name), serviceType: type });
+      service.callService(new ROSLIB.ServiceRequest(values), resolve, reject);
+    });
+  }
+
+  function App() {
+    const [bridgeUrl, setBridgeUrl] = React.useState(`ws://${window.location.hostname}:${defaultBridgePort}`);
+    const [robotNs, setRobotNs] = React.useState(initialRobotNs);
+    const [filter, setFilter] = React.useState('');
+    const [graph, setGraph] = React.useState({ nodes: [], topics: [] });
+    const [selected, setSelected] = React.useState(null);
+    const [details, setDetails] = React.useState(null);
+    const [preview, setPreview] = React.useState(null);
+    const [urdf, setUrdf] = React.useState('');
+    const [lastUpdate, setLastUpdate] = React.useState('never');
+    const { connected, error, ros } = useRosConnection(bridgeUrl);
+
+    const refresh = React.useCallback(async () => {
+      if (!ros || !connected) return;
+      try {
+        const [nodes, topics] = await Promise.all([
+          callService(ros, '/rosapi/nodes', 'rosapi/Nodes'),
+          callService(ros, '/rosapi/topics', 'rosapi/Topics'),
+        ]);
+        setGraph({ nodes: nodes.nodes || [], topics: topics.topics || [] });
+        setLastUpdate(new Date().toLocaleTimeString());
+      } catch (err) {
+        console.warn(err);
+      }
+    }, [ros, connected]);
+
+    React.useEffect(() => {
+      refresh();
+      const id = window.setInterval(refresh, 2000);
+      return () => window.clearInterval(id);
+    }, [refresh]);
+
+    // The URDF rarely changes, so fetch it once per connection/namespace.
+    React.useEffect(() => {
+      if (!ros || !connected) return undefined;
+      let alive = true;
+      callService(ros, '/rosapi/get_param', 'rosapi/GetParam', { name: `${robotNs}/robot_description`, default: '' })
+        .then((res) => {
+          if (!alive || !res.value) return;
+          let text = res.value;
+          try { text = JSON.parse(res.value); } catch (ignore) { /* rosapi may already return a plain string */ }
+          if (typeof text !== 'string') return;
+          setUrdf(text);
+        })
+        .catch(() => undefined);
+      return () => { alive = false; };
+    }, [ros, connected, robotNs]);
+
+    React.useEffect(() => {
+      if (!ros || !connected || !selected) return;
+      const load = async () => {
+        if (selected.kind === 'node') {
+          setDetails(await callService(ros, '/rosapi/node_details', 'rosapi/NodeDetails', { node: selected.name }));
+        } else {
+          const [type, publishers, subscribers] = await Promise.all([
+            callService(ros, '/rosapi/topic_type', 'rosapi/TopicType', { topic: selected.name }),
+            callService(ros, '/rosapi/publishers', 'rosapi/Publishers', { topic: selected.name }),
+            callService(ros, '/rosapi/subscribers', 'rosapi/Subscribers', { topic: selected.name }),
+          ]);
+          setDetails({ type: type.type, publishers: publishers.publishers || [], subscribers: subscribers.subscribers || [] });
+        }
+      };
+      setDetails(null);
+      load().catch((err) => setDetails({ error: String(err) }));
+    }, [ros, connected, selected]);
+
+    // Live message preview for the selected topic.
+    React.useEffect(() => {
+      setPreview(null);
+      if (!ros || !connected || selected?.kind !== 'topic' || !details?.type) return undefined;
+      const topic = new ROSLIB.Topic({
+        ros,
+        name: selected.name,
+        messageType: details.type,
+        throttle_rate: PREVIEW_THROTTLE_MS,
+        queue_length: 1,
+      });
+      topic.subscribe((msg) => setPreview(msg));
+      return () => topic.unsubscribe();
+    }, [ros, connected, selected, details]);
+
+    // Drive the URDF viewer from live joint states so the model mirrors the
+    // actual robot.
+    const viewerApiRef = React.useRef(null);
+    React.useEffect(() => {
+      if (!ros || !connected) return undefined;
+      const topic = new ROSLIB.Topic({
+        ros,
+        name: `${robotNs}/joint_states`,
+        messageType: 'sensor_msgs/JointState',
+        throttle_rate: 100,
+        queue_length: 1,
+      });
+      topic.subscribe((msg) => {
+        const values = {};
+        (msg.name || []).forEach((name, index) => { values[name] = msg.position?.[index] ?? 0; });
+        viewerApiRef.current?.setJointValues(values);
+      });
+      return () => topic.unsubscribe();
+    }, [ros, connected, robotNs]);
+
+    const lowerFilter = filter.toLowerCase();
+    const filteredNodes = graph.nodes.filter((name) => name.toLowerCase().includes(lowerFilter));
+    const filteredTopics = graph.topics.filter((name) => name.toLowerCase().includes(lowerFilter));
+
+    return e('main', { className: 'app' },
+      e('header', { className: 'app-header' },
+        e('h1', null, 'Aerial Robot Web Console'),
+        e('div', { className: 'status-row' },
+          e(InfoPill, { label: 'ROS Bridge', value: connected ? 'connected' : (error ? `${error} (retrying...)` : 'connecting...'), tone: connected ? 'ok' : error ? 'bad' : 'warn' }),
+          e(InfoPill, { label: 'Robot', value: `${robotType}${robotNs ? ` @ ${robotNs}` : ''}` }),
+          e(InfoPill, { label: 'Nodes / Topics', value: `${graph.nodes.length} / ${graph.topics.length}` }),
+          e(InfoPill, { label: 'Last update', value: lastUpdate }),
+        ),
+      ),
+      e('section', { className: 'toolbar' },
+        e('div', { className: 'two-col' },
+          e('label', { className: 'field' },
+            e('span', { className: 'label' }, 'Bridge URL'),
+            e('input', { value: bridgeUrl, onChange: (ev) => setBridgeUrl(ev.target.value) }),
+          ),
+          e('label', { className: 'field' },
+            e('span', { className: 'label' }, 'Namespace'),
+            e('input', { value: robotNs, onChange: (ev) => setRobotNs(normalizeNs(ev.target.value)), placeholder: '/robot_ns' }),
+          ),
+          e('label', { className: 'field' },
+            e('span', { className: 'label' }, 'Filter'),
+            e('input', { value: filter, onChange: (ev) => setFilter(ev.target.value), placeholder: 'Filter nodes/topics...' }),
+          ),
+        ),
+        e('button', { onClick: refresh, disabled: !connected }, 'Refresh'),
+      ),
+      e('section', { className: 'cards' },
+        e(GraphList, { title: 'Nodes', items: filteredNodes, kind: 'node', selected, setSelected, connected, loading: lastUpdate === 'never' }),
+        e(GraphList, { title: 'Topics', items: filteredTopics, kind: 'topic', selected, setSelected, connected, loading: lastUpdate === 'never' }),
+        e(DetailsCard, { selected, details, preview }),
+      ),
+      e(UrdfPanel, { urdf, viewerApiRef }),
+    );
+  }
+
+  function InfoPill({ label, value, tone }) {
+    return e('div', { className: 'pill' }, e('span', { className: 'label' }, label), e('span', { className: `value ${tone || ''}` }, value));
+  }
+
+  function GraphList({ title, items, kind, selected, setSelected, connected, loading }) {
+    let body;
+    if (items.length) {
+      body = items.map((name) => e('button', {
+        key: `${kind}:${name}`,
+        className: `item ${selected?.kind === kind && selected?.name === name ? 'active' : ''}`,
+        onClick: () => setSelected({ kind, name }),
+      }, name));
+    } else if (!connected) {
+      body = e('div', { className: 'empty' }, 'Waiting for rosbridge connection...');
+    } else if (loading) {
+      body = e('div', { className: 'skeleton', 'aria-hidden': 'true' },
+        e('div', { className: 'skeleton-row' }), e('div', { className: 'skeleton-row' }), e('div', { className: 'skeleton-row' }));
+    } else {
+      body = e('div', { className: 'empty' }, 'No matching entries');
+    }
+    return e('article', { className: 'card' },
+      e('h2', null, `${title} (${items.length})`),
+      e('div', { className: 'list' }, body),
+    );
+  }
+
+  function formatPreview(message) {
+    let text;
+    try {
+      text = JSON.stringify(message, null, 2);
+    } catch (ignore) {
+      text = String(message);
+    }
+    if (text.length > PREVIEW_MAX_CHARS) text = `${text.slice(0, PREVIEW_MAX_CHARS)}\n... (truncated)`;
+    return text;
+  }
+
+  function DetailsCard({ selected, details, preview }) {
+    const list = (label, values) => e('div', { className: 'section' }, e('span', { className: 'label' }, label), (values || []).map((value) => e('div', { className: 'meta', key: value }, value)));
+    return e('article', { className: 'card' },
+      e('h2', null, 'Info / Pub-Sub'),
+      selected ? e('div', null,
+        e('div', { className: 'topic-row' }, e('strong', null, selected.name), e('span', { className: 'badge' }, selected.kind)),
+        details?.error && e('p', { className: 'value bad' }, details.error),
+        !details && !preview && e('div', { className: 'empty' }, 'Loading details...'),
+        selected.kind === 'node' && details && !details.error && e(React.Fragment, null, list('Publications', details.publications), list('Subscriptions', details.subscriptions), list('Services', details.services)),
+        selected.kind === 'topic' && details && !details.error && e(React.Fragment, null,
+          e('p', { className: 'meta' }, `type: ${details.type || 'unknown'}`),
+          list('Publishers', details.publishers),
+          list('Subscribers', details.subscribers),
+          e('div', { className: 'section' },
+            e('span', { className: 'label' }, 'Latest message'),
+            preview ? e('pre', { className: 'preview' }, formatPreview(preview)) : e('div', { className: 'meta' }, 'Waiting for a message...'),
+          ),
+        ),
+      ) : e('div', { className: 'empty' }, 'Select a node or topic'),
+    );
+  }
+
+  function UrdfPanel({ urdf, viewerApiRef }) {
+    const ref = React.useRef(null);
+    const [message, setMessage] = React.useState('Waiting for robot_description...');
+    const [meshNotice, setMeshNotice] = React.useState('');
+    React.useEffect(() => {
+      if (!urdf || !ref.current) return undefined;
+      if (!window.AerialRobotUrdfViewer) {
+        setMessage('URDF viewer module is still loading.');
+        return undefined;
+      }
+      let cancelled = false;
+      setMeshNotice('');
+      const options = {
+        onMeshError: (count) => !cancelled && setMeshNotice(`${count} mesh file(s) failed to load; showing partial model.`),
+      };
+      window.AerialRobotUrdfViewer(ref.current, urdf, options).then((viewer) => {
+        if (cancelled) {
+          viewer.dispose();
+          return;
+        }
+        viewerApiRef.current = viewer;
+        setMessage('');
+      }).catch((err) => setMessage(`3D viewer unavailable: ${err.message || err}`));
+      return () => {
+        cancelled = true;
+        viewerApiRef.current?.dispose();
+        viewerApiRef.current = null;
+      };
+    }, [urdf, viewerApiRef]);
+    return e('section', { className: 'card section' },
+      e('h2', null, 'URDF Viewer'),
+      e('p', { className: 'meta' }, 'Touch-drag to orbit. The model follows live /joint_states.'),
+      e('div', { className: 'viewer', ref }, message && e('div', { className: 'empty' }, message)),
+      meshNotice && e('p', { className: 'meta' }, meshNotice),
+    );
+  }
+
+  ReactDOM.createRoot(document.getElementById('root')).render(e(App));
+})();

--- a/aerial_robot_web/www/index.html
+++ b/aerial_robot_web/www/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Aerial Robot Web Console</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/roslib/build/roslib.min.js"></script>
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "https://cdn.jsdelivr.net/npm/three@0.161.0/build/three.module.js",
+          "three/examples/jsm/": "https://cdn.jsdelivr.net/npm/three@0.161.0/examples/jsm/"
+        }
+      }
+    </script>
+    <script type="module" src="urdf-viewer.js"></script>
+  </head>
+  <body>
+    <div id="root">
+      <div class="boot-fallback">
+        <h1>Aerial Robot Web Console</h1>
+        <p>Loading interface assets&hellip;</p>
+        <p class="boot-hint">
+          If this message does not disappear, this device cannot reach the CDN that hosts
+          React and roslib (internet access is required once to cache them).
+        </p>
+      </div>
+    </div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/aerial_robot_web/www/styles.css
+++ b/aerial_robot_web/www/styles.css
@@ -1,0 +1,145 @@
+@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&family=Fira+Sans:wght@300;400;500;600;700&display=swap');
+
+:root {
+  color-scheme: dark;
+  --bg: #0b1020;
+  --surface: #121a2e;
+  --surface-2: #0d1426;
+  --line: rgba(148, 163, 184, 0.18);
+  --text: #e5eefb;
+  --muted: #9fb0c7;
+  --accent: #62d3ff;
+  --ok: #34d399;
+  --warn: #fbbf24;
+  --bad: #fb7185;
+  --radius-card: 12px;
+  --radius-control: 8px;
+  --font-body: "Fira Sans", Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-data: "Fira Code", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-family: var(--font-body);
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  min-height: 100dvh;
+  background: var(--bg);
+  color: var(--text);
+}
+button, input, select { font: inherit; touch-action: manipulation; }
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+.app {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+  padding: 16px max(14px, env(safe-area-inset-right)) calc(48px + env(safe-area-inset-bottom)) max(14px, env(safe-area-inset-left));
+}
+.app-header {
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-card);
+  background: var(--surface);
+}
+.app-header h1 { margin: 0; font-size: 1.35rem; letter-spacing: -0.02em; }
+h1, h2, h3 { font-family: var(--font-data); }
+.status-row, .toolbar, .cards, .two-col, .joint-row, .topic-row { display: grid; gap: 12px; }
+.status-row { grid-template-columns: repeat(auto-fit, minmax(155px, 1fr)); margin-top: 14px; }
+.pill, .card, .toolbar {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-card);
+  background: var(--surface);
+}
+.pill { padding: 12px; background: var(--surface-2); }
+.label { display: block; color: var(--muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.06em; }
+.value {
+  display: block; margin-top: 4px; font-weight: 700; overflow-wrap: anywhere;
+  font-family: var(--font-data); font-variant-numeric: tabular-nums; font-size: 0.92rem;
+}
+.value.ok { color: var(--ok); } .value.warn { color: var(--warn); } .value.bad { color: var(--bad); }
+.toolbar { grid-template-columns: 1fr auto; padding: 12px; margin: 14px 0; align-items: end; }
+.field { display: grid; gap: 4px; }
+.field .label { font-size: 0.72rem; }
+.toolbar input, .toolbar select {
+  width: 100%; padding: 12px 14px; border-radius: var(--radius-control); border: 1px solid var(--line);
+  background: var(--surface-2); color: var(--text);
+  transition: border-color 180ms ease-out, box-shadow 180ms ease-out;
+}
+.toolbar input:focus, .toolbar select:focus {
+  outline: none; border-color: var(--accent); box-shadow: 0 0 0 2px rgba(98, 211, 255, 0.15);
+}
+button {
+  border: 0; border-radius: var(--radius-control); padding: 12px 14px; min-height: 44px; cursor: pointer;
+  background: var(--accent); color: #06101e; font-weight: 700;
+  transition: filter 180ms ease-out, transform 120ms ease-out;
+}
+button:hover:not(:disabled) { filter: brightness(1.12); }
+button:active:not(:disabled) { transform: translateY(1px); }
+button.secondary { background: rgba(148, 163, 184, 0.14); color: var(--text); border: 1px solid var(--line); }
+button:disabled { opacity: 0.5; cursor: default; }
+.cards { grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); }
+.card { padding: 15px; min-width: 0; }
+.card h2, .card h3 { margin: 0 0 12px; letter-spacing: -0.02em; font-size: 1.05rem; }
+.list { display: grid; gap: 8px; max-height: 460px; overflow: auto; padding-right: 2px; }
+.item {
+  padding: 12px; border-radius: var(--radius-control); background: var(--surface-2); border: 1px solid transparent;
+  color: var(--text); text-align: left; width: 100%; overflow-wrap: anywhere; min-height: 44px;
+  font-family: var(--font-data); font-size: 0.84rem; font-weight: 400;
+  transition: background 180ms ease-out, border-color 180ms ease-out;
+}
+.item:hover { background: rgba(98, 211, 255, 0.07); border-color: rgba(98, 211, 255, 0.3); }
+.item.active { border-color: var(--accent); background: rgba(98, 211, 255, 0.1); }
+.meta { margin-top: 6px; color: var(--muted); font-size: 0.86rem; overflow-wrap: anywhere; }
+.two-col { grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+.section { margin-top: 14px; }
+.topic-row { grid-template-columns: 1fr auto; align-items: center; }
+.topic-row strong { font-family: var(--font-data); font-size: 0.9rem; overflow-wrap: anywhere; }
+.badge {
+  display: inline-flex; padding: 4px 9px; border-radius: 999px; background: rgba(98, 211, 255, 0.12);
+  color: var(--accent); font-size: 0.78rem; font-family: var(--font-data); font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.joint-row { grid-template-columns: 1fr; padding: 12px; border-radius: var(--radius-control); background: var(--surface-2); }
+.joint-head { display: flex; justify-content: space-between; gap: 12px; align-items: baseline; }
+.joint-head strong { font-family: var(--font-data); font-size: 0.88rem; }
+input[type="range"] { accent-color: var(--accent); width: 100%; min-height: 44px; margin: 0; cursor: pointer; }
+input[type="range"]:disabled { cursor: default; }
+.viewer { min-height: 360px; border-radius: var(--radius-card); overflow: hidden; background: var(--surface-2); border: 1px solid var(--line); }
+.viewer canvas { display: block; width: 100%; height: 360px; touch-action: none; }
+.empty { color: var(--muted); padding: 20px; text-align: center; border: 1px dashed var(--line); border-radius: var(--radius-card); }
+.skeleton { display: grid; gap: 8px; }
+.skeleton-row {
+  height: 44px; border-radius: var(--radius-control);
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0.08) 25%, rgba(148, 163, 184, 0.18) 50%, rgba(148, 163, 184, 0.08) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+@keyframes shimmer { from { background-position: 200% 0; } to { background-position: -200% 0; } }
+.preview {
+  margin: 8px 0 0; padding: 12px; max-height: 280px; overflow: auto;
+  border-radius: var(--radius-control); border: 1px solid var(--line); background: var(--surface-2);
+  color: var(--text); font-family: var(--font-data); font-variant-numeric: tabular-nums;
+  font-size: 0.8rem; line-height: 1.5; white-space: pre-wrap; overflow-wrap: anywhere;
+}
+.card-head { display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; }
+.card-head h2 { margin: 0; }
+.card-head button { min-height: 38px; padding: 8px 14px; }
+.boot-fallback {
+  width: min(640px, 92%); margin: 18vh auto 0; padding: 26px; text-align: center;
+  border: 1px solid var(--line); border-radius: var(--radius-card); background: var(--surface);
+}
+.boot-fallback h1 { margin: 0 0 10px; letter-spacing: -0.02em; }
+.boot-fallback p { margin: 6px 0; color: var(--muted); }
+.boot-hint { font-size: 0.86rem; }
+@media (max-width: 700px) {
+  .app { padding: 12px max(10px, env(safe-area-inset-right)) calc(40px + env(safe-area-inset-bottom)) max(10px, env(safe-area-inset-left)); }
+  .toolbar { grid-template-columns: 1fr; }
+  .cards { grid-template-columns: 1fr; }
+  .list { max-height: 330px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
+  .skeleton-row { animation: none; background: rgba(148, 163, 184, 0.12); }
+}

--- a/aerial_robot_web/www/urdf-viewer.js
+++ b/aerial_robot_web/www/urdf-viewer.js
@@ -1,0 +1,121 @@
+let DEPS = null;
+
+async function loadDependencies() {
+  if (DEPS) return DEPS;
+  const THREE = await import('three');
+  const { OrbitControls } = await import('three/examples/jsm/controls/OrbitControls.js');
+  const URDFLoader = (await import('https://cdn.jsdelivr.net/npm/urdf-loader@0.12.6/src/URDFLoader.js')).default;
+  DEPS = { THREE, OrbitControls, URDFLoader };
+  return DEPS;
+}
+
+const VIEWER_HEIGHT = 360;
+
+window.AerialRobotUrdfViewer = async function renderUrdfViewer(container, urdfText, options = {}) {
+  const { THREE, OrbitControls, URDFLoader } = await loadDependencies();
+  container.replaceChildren();
+
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x0d1426);
+  const camera = new THREE.PerspectiveCamera(45, (container.clientWidth || 320) / VIEWER_HEIGHT, 0.01, 1000);
+  const renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setPixelRatio(window.devicePixelRatio || 1);
+  renderer.setSize(container.clientWidth || 320, VIEWER_HEIGHT);
+  container.appendChild(renderer.domElement);
+
+  scene.add(new THREE.AmbientLight(0xffffff, 0.75));
+  const light = new THREE.DirectionalLight(0xffffff, 0.9);
+  light.position.set(3, 5, 4);
+  scene.add(light);
+  const grid = new THREE.GridHelper(4, 20, 0x33506c, 0x1f2a44);
+  scene.add(grid);
+
+  // STL/DAE meshes load asynchronously through the manager; framing is
+  // redone in onLoad once real geometry exists.
+  const manager = new THREE.LoadingManager();
+  const failedMeshes = [];
+  manager.onError = (url) => {
+    failedMeshes.push(url);
+    options.onMeshError?.(failedMeshes.length);
+  };
+
+  const loader = new URDFLoader(manager);
+  // Meshes referenced as package://<pkg>/<path> are served by the console
+  // HTTP server under /pkg/<pkg>/<path>.
+  loader.packages = (pkg) => `/pkg/${pkg}`;
+  const robot = loader.parse(urdfText);
+  robot.rotation.x = -Math.PI / 2;
+  scene.add(robot);
+
+  const controls = new OrbitControls(camera, renderer.domElement);
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.08;
+
+  const frame = () => {
+    const box = new THREE.Box3().setFromObject(robot);
+    if (box.isEmpty()) return;
+    const center = box.getCenter(new THREE.Vector3());
+    const size = box.getSize(new THREE.Vector3());
+    robot.position.sub(center);
+    const maxDim = Math.max(size.x, size.y, size.z, 0.1);
+    camera.position.set(maxDim * 1.8, maxDim * 1.6, maxDim * 1.2);
+    camera.near = maxDim / 100;
+    camera.far = maxDim * 100;
+    camera.updateProjectionMatrix();
+    grid.position.y = -size.y / 2;
+    controls.target.set(0, 0, 0);
+    controls.update();
+  };
+  frame();
+  manager.onLoad = frame;
+
+  const resize = () => {
+    const width = container.clientWidth || 320;
+    camera.aspect = width / VIEWER_HEIGHT;
+    camera.updateProjectionMatrix();
+    renderer.setSize(width, VIEWER_HEIGHT);
+  };
+  let resizeObserver = null;
+  if (window.ResizeObserver) {
+    resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(container);
+  } else {
+    window.addEventListener('resize', resize);
+  }
+
+  let running = true;
+  const animate = () => {
+    if (!running) return;
+    requestAnimationFrame(animate);
+    controls.update();
+    renderer.render(scene, camera);
+  };
+  animate();
+
+  return {
+    setJointValues(values) {
+      if (typeof robot.setJointValues === 'function') {
+        robot.setJointValues(values);
+      } else {
+        Object.entries(values).forEach(([name, value]) => robot.joints?.[name]?.setJointValue(value));
+      }
+    },
+    dispose() {
+      running = false;
+      manager.onLoad = undefined;
+      if (resizeObserver) resizeObserver.disconnect();
+      else window.removeEventListener('resize', resize);
+      controls.dispose();
+      scene.traverse((obj) => {
+        obj.geometry?.dispose?.();
+        const materials = Array.isArray(obj.material) ? obj.material : (obj.material ? [obj.material] : []);
+        materials.forEach((material) => {
+          Object.values(material).forEach((value) => value?.isTexture && value.dispose());
+          material.dispose();
+        });
+      });
+      renderer.dispose();
+      container.replaceChildren();
+    },
+  };
+};

--- a/robots/dragon/launch/bringup.launch
+++ b/robots/dragon/launch/bringup.launch
@@ -29,6 +29,12 @@
   <arg name="mujoco" default="False" />
   <arg name="robot_id" default="" />
   <arg name="robot_ns" value="dragon$(arg robot_id)" />
+
+  ###########  Mobile Web Console  ###########
+  <arg name="launch_web_console" default="True" />
+  <arg name="web_console_port" default="8080" />
+  <arg name="web_console_rosbridge_port" default="9090" />
+  <arg name="web_console_launch_rosbridge" default="True" />
   <arg name="config_dir" default="$(find dragon)/config/$(arg link_num)/$(arg model_name)" />
 
   <arg name="demo" default="True" />
@@ -127,6 +133,16 @@
 
   ########## Simple Demo #########
   <node pkg="dragon" type="simple_demo.py" name="simple_demo" ns="$(arg robot_ns)" output="screen" if="$(arg demo)"/>
+
+
+  ###########  Mobile Web Console  ###########
+  <include file="$(find aerial_robot_web)/launch/web_console.launch" if="$(arg launch_web_console)">
+    <arg name="robot_ns" value="$(arg robot_ns)" />
+    <arg name="robot_type" value="dragon" />
+    <arg name="web_port" value="$(arg web_console_port)" />
+    <arg name="rosbridge_port" value="$(arg web_console_rosbridge_port)" />
+    <arg name="launch_rosbridge" value="$(arg web_console_launch_rosbridge)" />
+  </include>
 
 </launch>
 

--- a/robots/gimbalrotor/launch/bringup.launch
+++ b/robots/gimbalrotor/launch/bringup.launch
@@ -20,6 +20,12 @@
   <arg name="config_dir" default="$(find gimbalrotor)/config"/>
   <arg name="robot_id" default="" />
   <arg name="robot_ns" value="gimbalrotor$(arg robot_id)" />
+
+  ###########  Mobile Web Console  ###########
+  <arg name="launch_web_console" default="True" />
+  <arg name="web_console_port" default="8080" />
+  <arg name="web_console_rosbridge_port" default="9090" />
+  <arg name="web_console_launch_rosbridge" default="True" />
   <arg name="airframe" default="quad" />
 
   ###########  Parameters  ###########
@@ -98,6 +104,16 @@
     <arg name="spawn_y" value="$(arg spawn_y)" />
     <arg name="spawn_z" value="$(arg spawn_z)" />
     <arg name="spawn_yaw" value="$(arg spawn_yaw)" />
+  </include>
+
+
+  ###########  Mobile Web Console  ###########
+  <include file="$(find aerial_robot_web)/launch/web_console.launch" if="$(arg launch_web_console)">
+    <arg name="robot_ns" value="$(arg robot_ns)" />
+    <arg name="robot_type" value="gimbalrotor" />
+    <arg name="web_port" value="$(arg web_console_port)" />
+    <arg name="rosbridge_port" value="$(arg web_console_rosbridge_port)" />
+    <arg name="launch_rosbridge" value="$(arg web_console_launch_rosbridge)" />
   </include>
 
 </launch>

--- a/robots/hydrus/launch/bringup.launch
+++ b/robots/hydrus/launch/bringup.launch
@@ -18,6 +18,12 @@
   <arg name="spawn_yaw" default="0.0"/>
   <arg name="robot_id" default="" />
   <arg name="robot_ns" value="hydrus$(arg robot_id)" />
+
+  ###########  Mobile Web Console  ###########
+  <arg name="launch_web_console" default="True" />
+  <arg name="web_console_port" default="8080" />
+  <arg name="web_console_rosbridge_port" default="9090" />
+  <arg name="web_console_launch_rosbridge" default="True" />
   <arg name="config_dir" default="$(find hydrus)/config/$(arg type)" />
   <arg name="mujoco" default="False" />
   <arg name="demo" default="True" />
@@ -110,5 +116,15 @@
 
   ########## Simple Demo #########
   <node pkg="hydrus" type="loop_demo.py" name="loop_demo" ns="$(arg robot_ns)" output="screen" if="$(arg demo)"/>
+
+
+  ###########  Mobile Web Console  ###########
+  <include file="$(find aerial_robot_web)/launch/web_console.launch" if="$(arg launch_web_console)">
+    <arg name="robot_ns" value="$(arg robot_ns)" />
+    <arg name="robot_type" value="hydrus" />
+    <arg name="web_port" value="$(arg web_console_port)" />
+    <arg name="rosbridge_port" value="$(arg web_console_rosbridge_port)" />
+    <arg name="launch_rosbridge" value="$(arg web_console_launch_rosbridge)" />
+  </include>
 
 </launch>

--- a/robots/hydrus_xi/launch/bringup.launch
+++ b/robots/hydrus_xi/launch/bringup.launch
@@ -23,6 +23,12 @@
   <arg name="spawn_yaw" default="0.0"/>
   <arg name="robot_id" default="" />
   <arg name="robot_ns" value="hydrus_xi$(arg robot_id)" />
+
+  ###########  Mobile Web Console  ###########
+  <arg name="launch_web_console" default="True" />
+  <arg name="web_console_port" default="8080" />
+  <arg name="web_console_rosbridge_port" default="9090" />
+  <arg name="web_console_launch_rosbridge" default="True" />
   <arg name="mujoco" default="False" />
   <arg name="demo" default="True" />
 
@@ -115,5 +121,15 @@
 
   ########## Simple Demo #########
   <node pkg="aerial_robot_base" type="simple_demo.py" name="simple_demo" ns="$(arg robot_ns)" output="screen" if="$(arg demo)"/>
+
+
+  ###########  Mobile Web Console  ###########
+  <include file="$(find aerial_robot_web)/launch/web_console.launch" if="$(arg launch_web_console)">
+    <arg name="robot_ns" value="$(arg robot_ns)" />
+    <arg name="robot_type" value="hydrus_xi" />
+    <arg name="web_port" value="$(arg web_console_port)" />
+    <arg name="rosbridge_port" value="$(arg web_console_rosbridge_port)" />
+    <arg name="launch_rosbridge" value="$(arg web_console_launch_rosbridge)" />
+  </include>
 
 </launch>

--- a/robots/mini_quadrotor/launch/bringup.launch
+++ b/robots/mini_quadrotor/launch/bringup.launch
@@ -18,6 +18,12 @@
   <arg name="spawn_yaw" default="0.0"/>
   <arg name="robot_id" default="" />
   <arg name="robot_ns" value="quadrotor$(arg robot_id)" />
+
+  ###########  Mobile Web Console  ###########
+  <arg name="launch_web_console" default="True" />
+  <arg name="web_console_port" default="8080" />
+  <arg name="web_console_rosbridge_port" default="9090" />
+  <arg name="web_console_launch_rosbridge" default="True" />
   <arg name="config_dir" default="$(find mini_quadrotor)/config" />
   <arg name="mujoco" default="False" />
   <arg name="demo" default="True" />
@@ -102,5 +108,15 @@
   ########## Simple Demo #########
   <node pkg="aerial_robot_base" type="simple_demo.py" name="simple_demo" ns="$(arg robot_ns)" output="screen" if="$(arg demo)"/>
 
+
+
+  ###########  Mobile Web Console  ###########
+  <include file="$(find aerial_robot_web)/launch/web_console.launch" if="$(arg launch_web_console)">
+    <arg name="robot_ns" value="$(arg robot_ns)" />
+    <arg name="robot_type" value="mini_quadrotor" />
+    <arg name="web_port" value="$(arg web_console_port)" />
+    <arg name="rosbridge_port" value="$(arg web_console_rosbridge_port)" />
+    <arg name="launch_rosbridge" value="$(arg web_console_launch_rosbridge)" />
+  </include>
 
 </launch>


### PR DESCRIPTION
### What is this

This PR adds a shared browser-based web console for aerial robots and integrates it into existing robot bringup launch files.

The web console provides a lightweight interface for monitoring robot state and visualizing the robot model from a browser.

### Details

Please explain the contribution of this PR in detail.

- commit1: Add the `aerial_robot_web` package, including the web server, launch file, frontend files, URDF viewer support, package metadata, and README.
- commit2: Add optional web console launch support to the bringup launch files for Dragon, Gimbalrotor, Hydrus, Hydrus XI, and Mini Quadrotor.

### TODO

If there is still some work to do. Plase list up as follows:

- [ ] Test the web console with each supported robot bringup in the target ROS environment
- [ ] Add a demo video if available

### Video

N/A