### PR TITLE
feat(dracomancer): 操作者IMU連動の相対移動とCOG/baselink切替を追加

### DIFF
--- a/robots/dracomancer/CLAUDE.md
+++ b/robots/dracomancer/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md — dracomancer パッケージ
+
+このファイルは `robots/dracomancer/` を編集する際に Claude が参照する前提知識です。
+ユーザーのグローバル指示（日本語での結論先出し・小さな変更・確認の徹底など）に従うこと。
+
+## このパッケージは何か
+
+Dracomancer は **DRAGON を遠隔操作する上肢外骨格（エクソスケルトン）デバイス**。
+オペレータの腕の関節角と操縦桿、背中の IMU を読み取り、DRAGON の
+**移動指令（FlightNav）** と **形状指令（joints_ctrl）** に変換する。
+
+- 実体は `scripts/` 配下の **Python ノード**。
+- `src/`（`dracomancer.cpp`, `model/`, `control/`）と `include/` は**現状すべて空のプレースホルダ**。
+  C++ プラグイン（`plugins/*.xml`）は宣言のみで中身がない。安易に「実装済み」と扱わないこと。
+
+## ファイル構成と役割
+
+| パス | 役割 |
+| --- | --- |
+| `scripts/joystick_calib_publisher.py` | 操縦桿の生値較正 → `/dracomancer/joystick/calibrated` |
+| `scripts/servo_to_joint_states.py` | サーボ tick → rad の関節状態。ID0〜6 を固定マッピング |
+| `scripts/control_pose.py` | 操縦桿(+IMU) → DRAGON 移動指令 `/<robot>/uav/nav` |
+| `scripts/control_joints.py` | 腕関節 → DRAGON 形状指令 `/<robot>/joints_ctrl`（形状安全付き） |
+| `launch/bringup.launch` | デバイス本体（URDF/TF/サーボ橋渡し/FC） |
+| `launch/teleoperation.launch` | 操作変換ノード群。control_pose/control_joints の引数集約 |
+| `launch/include/sensors.launch.xml` | spinal bridge（FC/IMU）と imu 設定読込 |
+| `config/` | Servo/joystick_calibration/navigation 等の設定 |
+| `docs/` | 仕様ドキュメント（中粒度・Mermaid 図中心） |
+
+## 重要な前提・規約
+
+- **編集はできるだけ `dracomancer/` 内にとどめる**（ユーザー指示）。
+  共通機能（`aerial_robot_model` 等）の変更が必要なときは事前に相談する。
+- **トピック名**
+  - 操縦桿: `/joystick/raw`(Int16MultiArray) → `/dracomancer/joystick/calibrated`(Float32MultiArray)
+  - サーボ: `/servo/states`(spinal/ServoStates) → `/dracomancer/joint_states`(JointState)
+  - IMU: `/dracomancer/imu`（spinal/Imu, `quaternion[x,y,z,w]`）。namespace `dracomancer` 下の spinal bridge が publish。
+  - DRAGON 出力: `/dragon/uav/nav`(FlightNav), `/dragon/joints_ctrl`(JointState)
+- **spinal.msg** は `servo_to_joint_states.py` / `control_pose.py` で使用。`package.xml` に `spinal` run_depend を宣言済み。
+- **rm / sim** が通常の起動引数。`real_machine` / `simulation` は旧互換エイリアス。
+- Khadas など表示なし環境を想定し、RViz は既定で起動しない（`headless` 既定 True）。
+
+## FlightNav（aerial_robot_msgs）の要点
+
+移動指令で使う主フィールド:
+- `control_frame`: `WORLD_FRAME(0)` / `LOCAL_FRAME(1)`
+- `target`: `BASELINK(0)` / `COG(1)`
+- `*_nav_mode`: `POS_VEL_MODE(4)` などを使用。control_pose は速度指令（`target_vel_*`）を送る。
+
+## control_pose.py（移動制御）の設計
+
+IMU（spinal 由来。操作者の背中に **90度傾けて** 搭載）の姿勢で、操縦桿の移動方向を
+**操作者の向きに対する相対移動**に変換する。重心/ベースリンク切替も持つ。
+
+主なパラメータ:
+- `nav_target`: `cog`(既定) / `baselink` → FlightNav.target。
+- `direction_mode`: `none` / `yaw`(既定) / `yaw_pitch` / `full`。
+- `imu_topic`: 既定 `/dracomancer/imu`。
+- `imu_mount_rpy`: IMU 取付け補正 [roll,pitch,yaw] rad（既定 `[0, -π/2, 0]`、実機で要調整）。
+- `recapture_on_hover`: ホバ開始時に中立姿勢を再キャプチャ（既定 true）。
+- `~recapture_neutral`(std_msgs/Empty): 中立再キャプチャのトリガ。
+
+### 数学的に重要な事実（変更時の注意）
+
+- 操作者の向きは `q_wo = q_spinal ⊗ q_mount`（操作者ボディ→ワールド）で表す。
+- 起動時に中立 `q_wo0` をキャプチャし、ワールド相対回転
+  `q_rel = q_wo ⊗ q_wo0⁻¹` を用いる。
+- **`yaw` モードでは取付け補正 `q_mount` がキャンセルされる**
+  （`q_rel = q_spinal ⊗ q_spinal0⁻¹` となるため）。ヨー操舵は取付け角に依存しない。
+  → `imu_mount_rpy` が効くのは `yaw_pitch` / `full`（操作者の前方軸=ボディx が必要）のみ。
+- spinal は磁気を使わないと **yaw がドリフト**する。だから絶対値ではなく
+  中立キャプチャ（相対）方式を採用している。`recapture_on_hover` で離陸直前に取り直す。
+- 四元数は `[x,y,z,w]` 規約。ヘルパー（quat_mult 等）は numpy 自前実装で外部依存なし。
+
+## ビルド / 動作確認
+
+```bash
+catkin build aerial_robot_model dracomancer
+source devel/setup.bash
+python3 -m py_compile robots/dracomancer/scripts/*.py   # 構文チェック
+```
+
+実機がなくても Python の構文チェックと、回転ロジックの数値検証は可能。
+ROS ノードの起動には spinal/aerial_robot 一式が必要。
+
+## ドキュメント
+
+実装を変えたら `docs/` を更新すること（中粒度・Mermaid 図・日本語）。
+- `docs/02_dataflow.md`: トピックフロー
+- `docs/05_bringup.md`: 起動引数
+- `docs/06_imu_relative_control.md`: IMU 相対移動 / COG・baselink 切替

--- a/robots/dracomancer/docs/01_overview.md
+++ b/robots/dracomancer/docs/01_overview.md
@@ -28,7 +28,7 @@ flowchart TB
 | --- | --- | --- | --- |
 | `joystick_calib_publisher.py` | 操縦桿の生値を較正して正規化 | `/joystick/raw` | `/dracomancer/joystick/calibrated` |
 | `servo_to_joint_states.py` | サーボtick → ラジアンの関節状態へ変換 | `/servo/states` | `/dracomancer/joint_states` |
-| `control_pose.py` | 操縦桿 → DRAGON 機体の速度指令 | `calibrated`, `flight_state`, `mocap/pose` | `/dragon/uav/nav` |
+| `control_pose.py` | 操縦桿(+IMU) → DRAGON 機体の速度指令（操作者向き相対 / COG・baselink 切替） | `calibrated`, `imu`, `flight_state`, `mocap/pose` | `/dragon/uav/nav` |
 | `control_joints.py` | 腕関節 → DRAGON 形状指令（＋安全） | `joint_states`, `debug/fc_*`, `flight_state` | `/dragon/joints_ctrl`, `dragon_shape_safety` |
 
 ## デバイス側ハードウェア構成

--- a/robots/dracomancer/docs/02_dataflow.md
+++ b/robots/dracomancer/docs/02_dataflow.md
@@ -27,21 +27,26 @@ flowchart TB
 ## ① 位置系統（control_pose.py）
 
 操縦桿の傾きを **DRAGON の速度指令**（`FlightNav`）に変換します。
+さらに操作者の **IMU 姿勢**で移動方向を回転し、**操作者の向きに対する相対移動**にします。
 
 ```mermaid
 flowchart LR
     JOY["calibrated 軸値"] --> DZ["デッドゾーン処理<br/>(±0.05)"]
     DZ --> SC["スケール<br/>scale_x/y/z"]
-    SC --> VEL["速度に変換<br/>xy_vel=0.3, z_vel=0.2"]
-    VEL --> NAV["/dragon/uav/nav<br/>(POS_VEL_MODE)"]
+    SC --> VEL["body 速度ベクトル<br/>xy_vel=0.3, z_vel=0.2"]
+    VEL --> ROT["向き補正<br/>direction_mode"]
+    IMU["/dracomancer/imu<br/>(spinal Imu)"] -.->|操作者姿勢| ROT
+    ROT --> NAV["/dragon/uav/nav<br/>(WORLD_FRAME, POS_VEL_MODE)"]
 
     STATE["/dragon/flight_state"] -.->|hover中のみ送信| NAV
     POS["/dragon/mocap/pose"] -.->|位置リミット参照| NAV
+    TGT["nav_target<br/>cog / baselink"] -.->|移動対象| NAV
 ```
 
 要点:
 - DRAGON が**ホバリング状態（flight_state ≥ 4）になってから**指令を送信。ホバ直後は `wait_after_hover`（既定 3 秒）待機。
-- 制御モードは全軸 `POS_VEL_MODE`、対象は重心 `COG`、`WORLD_FRAME`。
+- 制御モードは全軸 `POS_VEL_MODE`、`WORLD_FRAME`。移動対象（COG / baselink）は `nav_target` で切替（既定 COG）。
+- IMU 姿勢による向き補正は `direction_mode`（`none`/`yaw`/`yaw_pitch`/`full`）で切替。詳細は [06. IMU 相対移動](06_imu_relative_control.md)。
 - `pos_limit` 有効時は部屋内の安全範囲（X/Y/Z）にクランプ。
 
 ## ② 形状系統（servo_to_joint_states → control_joints）
@@ -67,6 +72,7 @@ flowchart LR
 | `/joystick/raw` | `Int16MultiArray` | 入力 | 操縦桿の生値 |
 | `/dracomancer/joystick/calibrated` | `Float32MultiArray` | 内部 | 較正済み軸値 |
 | `/servo/states` | `spinal/ServoStates` | 入力 | 腕サーボの状態 |
+| `/dracomancer/imu` | `spinal/Imu` | 入力 | 操作者の姿勢（向き補正用） |
 | `/dracomancer/joint_states` | `JointState` | 内部 | 腕関節角 |
 | `/dragon/uav/nav` | `aerial_robot_msgs/FlightNav` | 出力 | DRAGON 速度指令 |
 | `/dragon/joints_ctrl` | `JointState` | 出力 | DRAGON 形状指令 |

--- a/robots/dracomancer/docs/05_bringup.md
+++ b/robots/dracomancer/docs/05_bringup.md
@@ -78,6 +78,11 @@ roslaunch dracomancer teleoperation.launch
 | `min_safety_scale` | 安全スケールの下限 |
 | `max_step` | 1 周期あたりの関節変化量上限 |
 | `publish_joints_only_when_hovering` | ホバリング以降のみ形状指令を送信 |
+| `nav_target` | 移動対象 `cog`(既定) / `baselink`（[06](06_imu_relative_control.md)） |
+| `direction_mode` | IMU 向き補正 `none`/`yaw`(既定)/`yaw_pitch`/`full` |
+| `imu_topic` | 操作者 IMU トピック（既定 `/dracomancer/imu`） |
+| `imu_mount_roll/pitch/yaw` | IMU 取付け補正 [rad]（実機で要調整） |
+| `recapture_neutral_on_hover` | ホバ開始時に中立向きを取り直す |
 
 ### シミュレーションで落下を許容（安全機構を緩和）
 

--- a/robots/dracomancer/docs/06_imu_relative_control.md
+++ b/robots/dracomancer/docs/06_imu_relative_control.md
@@ -1,0 +1,129 @@
+# 06. IMU 相対移動と移動対象切替
+
+`control_pose.py` は、操縦桿の移動指令を **操作者の向きに対する相対移動**へ変換し、
+さらに **重心(COG) / ベースリンク** の移動対象を切替えられます。
+
+## 全体像
+
+```mermaid
+flowchart LR
+    JOY["操縦桿<br/>(body 速度ベクトル)"] --> ROT["向き補正<br/>rotate_command"]
+    IMU["/dracomancer/imu<br/>(spinal Imu quaternion)"] --> ROT
+    ROT --> NAV["FlightNav<br/>target_vel_x/y/z<br/>(WORLD_FRAME)"]
+    TGT["nav_target<br/>cog / baselink"] --> NAV
+    NAV --> OUT["/dragon/uav/nav"]
+```
+
+操作者が向きを変えると、操縦桿「前」の指す世界方向が一緒に回転します
+（操作者の正面に対する相対移動）。
+
+```mermaid
+flowchart LR
+    subgraph N["中立（起動/ホバ開始時にキャプチャ）"]
+        FN["前 = +X(world)"]
+    end
+    subgraph T["操作者が +30度ヨー"]
+        FT["前 = +30度 方向"]
+    end
+    N --> T
+```
+
+## 向きの計算（中立相対）
+
+```mermaid
+flowchart TB
+    Q["q_spinal（board→world）"] --> WO["q_wo = q_spinal ⊗ q_mount<br/>(操作者body→world)"]
+    MNT["imu_mount_rpy<br/>(取付け補正)"] --> WO
+    WO --> CAP{"中立キャプチャ?<br/>起動 / ホバ開始 / 手動"}
+    CAP -->|はい| N0["q_wo0, neutral_yaw/pitch を保存"]
+    WO --> REL["相対回転<br/>q_rel = q_wo ⊗ q_wo0⁻¹"]
+    N0 --> REL
+    REL --> APPLY["direction_mode に応じて<br/>body ベクトルを回転"]
+```
+
+> **重要**: 中立キャプチャ方式では `yaw` モードのとき取付け補正 `q_mount` は
+> 数式上キャンセルされ、ヨー操舵は取付け角に依存しません。
+> `imu_mount_rpy` が効くのは `yaw_pitch` / `full` モードのみです。
+
+## direction_mode（4 種を引数で切替）
+
+```mermaid
+flowchart TD
+    MODE{"direction_mode"}
+    MODE -->|none| NONE["操縦桿をそのまま<br/>world 速度に（従来動作）"]
+    MODE -->|yaw| YAW["相対ヨーで水平回転<br/>Rz(Δyaw)・body"]
+    MODE -->|yaw_pitch| YP["ヨー+ピッチ<br/>Rz(Δyaw)・Ry(Δpitch)・body<br/>(roll 無視)"]
+    MODE -->|full| FULL["相対3D回転<br/>q_rel・body"]
+```
+
+| モード | 挙動 | 用途 |
+| --- | --- | --- |
+| `none` | 操縦桿＝world 速度（従来） | IMU を使わない |
+| `yaw`（既定） | 左右の向きで水平移動方向を回転 | 最も直感的 |
+| `yaw_pitch` | 前傾も移動方向に反映（roll 無視） | 体の傾きで上下方向も操作 |
+| `full` | roll/pitch/yaw すべて反映 | 全身姿勢で操作 |
+
+## 中立（正面）の基準
+
+spinal は磁気を使わないと yaw がドリフトするため、**相対方式**を採用しています。
+
+```mermaid
+flowchart LR
+    S1["起動後 最初の IMU"] --> CAP["中立キャプチャ"]
+    S2["ホバ開始の瞬間<br/>recapture_on_hover=true"] --> CAP
+    S3["~recapture_neutral<br/>(std_msgs/Empty)"] --> CAP
+```
+
+手動で取り直す:
+
+```bash
+rostopic pub -1 /dracomancer_control_pose/recapture_neutral std_msgs/Empty "{}"
+```
+
+## 移動対象（COG / baselink）の切替
+
+`FlightNav.target` を切替えます（既定 COG）。
+
+```mermaid
+flowchart LR
+    NT{"nav_target"}
+    NT -->|cog（既定）| COG["target = COG(1)<br/>重心基準で移動"]
+    NT -->|baselink| BL["target = BASELINK(0)<br/>ベースリンク基準で移動"]
+```
+
+## 主なパラメータ（teleoperation.launch 引数）
+
+| 引数 | 既定 | 説明 |
+| --- | --- | --- |
+| `nav_target` | `cog` | 移動対象（`cog` / `baselink`） |
+| `direction_mode` | `yaw` | 向き補正モード（`none`/`yaw`/`yaw_pitch`/`full`） |
+| `imu_topic` | `/dracomancer/imu` | spinal IMU トピック |
+| `imu_mount_roll/pitch/yaw` | `0 / -π/2 / 0` | IMU 取付け補正 [rad]（実機で要調整） |
+| `recapture_neutral_on_hover` | `true` | ホバ開始時に中立を取り直す |
+
+## 使用例
+
+操作者相対（ヨー）＋重心移動（既定）:
+
+```bash
+roslaunch dracomancer teleoperation.launch
+```
+
+ベースリンク移動・前傾も反映:
+
+```bash
+roslaunch dracomancer teleoperation.launch nav_target:=baselink direction_mode:=yaw_pitch
+```
+
+IMU を使わない従来動作:
+
+```bash
+roslaunch dracomancer teleoperation.launch direction_mode:=none
+```
+
+取付け補正を調整（例: roll 90度）:
+
+```bash
+roslaunch dracomancer teleoperation.launch \
+  direction_mode:=full imu_mount_roll:=1.5708 imu_mount_pitch:=0.0
+```

--- a/robots/dracomancer/docs/README.md
+++ b/robots/dracomancer/docs/README.md
@@ -12,6 +12,7 @@ Dracomancer は **DRAGON を遠隔操作するための上肢外骨格（エク�
 | 03 | [関節マッピング](03_joint_mapping.md) | Dracomancer 関節 → DRAGON 関節の対応 |
 | 04 | [形状安全機構](04_shape_safety.md) | 実現可能性に基づく指令スケーリング |
 | 05 | [起動方法](05_bringup.md) | launch 引数とよく使うコマンド |
+| 06 | [IMU 相対移動と移動対象切替](06_imu_relative_control.md) | 操作者の向きに応じた相対移動 / COG・baselink 切替 |
 
 ## 全体像（ひとめ）
 

--- a/robots/dracomancer/launch/teleoperation.launch
+++ b/robots/dracomancer/launch/teleoperation.launch
@@ -27,6 +27,20 @@
   <arg name="capture_neutral_on_first_msg" default="false"/>
   <arg name="enable_control_pose" default="true"/>
   <arg name="enable_control_joints" default="true"/>
+
+  <!-- pose (movement) control settings -->
+  <!-- nav_target: cog (重心) or baselink (ベースリンク) -->
+  <arg name="nav_target" default="cog"/>
+  <!-- direction_mode: none / yaw / yaw_pitch / full -->
+  <arg name="direction_mode" default="yaw"/>
+  <arg name="imu_topic" default="/$(arg device_ns)/imu"/>
+  <!-- IMU mounting correction (operator-body <- IMU board) [rad].
+       Default assumes the IMU is tilted 90deg on the operator's back.
+       Tune on the real hardware. -->
+  <arg name="imu_mount_roll" default="0.0"/>
+  <arg name="imu_mount_pitch" default="-1.57079632679"/>
+  <arg name="imu_mount_yaw" default="0.0"/>
+  <arg name="recapture_neutral_on_hover" default="true"/>
   <arg name="publish_joints_only_when_hovering" default="false"/>
   <arg name="publish_joints_before_device_ready" default="false"/>
 
@@ -85,11 +99,19 @@
     <param name="rate" value="40.0"/>
     <param name="joy_topic" value="$(arg js_calibrated_topic)"/>
 
+    <!-- Movement target and IMU-relative direction -->
+    <param name="nav_target" value="$(arg nav_target)"/>
+    <param name="direction_mode" value="$(arg direction_mode)"/>
+    <param name="imu_topic" value="$(arg imu_topic)"/>
+    <rosparam param="imu_mount_rpy"
+              subst_value="true">[$(arg imu_mount_roll), $(arg imu_mount_pitch), $(arg imu_mount_yaw)]</rosparam>
+    <param name="recapture_on_hover" value="$(arg recapture_neutral_on_hover)"/>
+
     <!-- Scaling and Threshold -->
     <param name="scale_x" value="1.0"/>
     <param name="scale_y" value="1.0"/>
     <param name="scale_z" value="1.0"/>
-    <param name="deadzone" value="0.05"/>    
+    <param name="deadzone" value="0.05"/>
   </node>
 
   <!-- Control Joints -->

--- a/robots/dracomancer/package.xml
+++ b/robots/dracomancer/package.xml
@@ -27,6 +27,7 @@
   <run_depend>aerial_robot_estimation</run_depend>
   <run_depend>aerial_robot_simulation</run_depend>
   <run_depend>aerial_robot_base</run_depend>
+  <run_depend>spinal</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>diagnostic_msgs</run_depend>

--- a/robots/dracomancer/scripts/control_pose.py
+++ b/robots/dracomancer/scripts/control_pose.py
@@ -1,25 +1,119 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import math
 import rospy
-from std_msgs.msg import Float32MultiArray, UInt8
+import numpy as np
+from std_msgs.msg import Float32MultiArray, UInt8, Empty
 from geometry_msgs.msg import PoseStamped, Vector3Stamped
 from aerial_robot_msgs.msg import FlightNav
+from spinal.msg import Imu as SpinalImu
+
+
+# --------------------------------------------------------------------------
+#  Quaternion / rotation helpers (numpy, [x, y, z, w] convention)
+# --------------------------------------------------------------------------
+def quat_normalize(q):
+    n = math.sqrt(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3])
+    if n < 1e-9:
+        return np.array([0.0, 0.0, 0.0, 1.0])
+    return np.array(q) / n
+
+
+def quat_mult(a, b):
+    ax, ay, az, aw = a
+    bx, by, bz, bw = b
+    return np.array([
+        aw * bx + ax * bw + ay * bz - az * by,
+        aw * by - ax * bz + ay * bw + az * bx,
+        aw * bz + ax * by - ay * bx + az * bw,
+        aw * bw - ax * bx - ay * by - az * bz,
+    ])
+
+
+def quat_inverse(q):
+    # unit quaternion -> conjugate
+    return np.array([-q[0], -q[1], -q[2], q[3]])
+
+
+def quat_rotate_vec(q, v):
+    # rotate vector v by quaternion q
+    qv = np.array([v[0], v[1], v[2], 0.0])
+    return quat_mult(quat_mult(q, qv), quat_inverse(q))[:3]
+
+
+def quat_from_euler(roll, pitch, yaw):
+    # intrinsic Rz(yaw) * Ry(pitch) * Rx(roll)
+    cr, sr = math.cos(roll * 0.5), math.sin(roll * 0.5)
+    cp, sp = math.cos(pitch * 0.5), math.sin(pitch * 0.5)
+    cy, sy = math.cos(yaw * 0.5), math.sin(yaw * 0.5)
+    return np.array([
+        sr * cp * cy - cr * sp * sy,
+        cr * sp * cy + sr * cp * sy,
+        cr * cp * sy - sr * sp * cy,
+        cr * cp * cy + sr * sp * sy,
+    ])
+
+
+def rot_z(a, v):
+    c, s = math.cos(a), math.sin(a)
+    return np.array([c * v[0] - s * v[1], s * v[0] + c * v[1], v[2]])
+
+
+def rot_y(a, v):
+    c, s = math.cos(a), math.sin(a)
+    return np.array([c * v[0] + s * v[2], v[1], -s * v[0] + c * v[2]])
+
+
+def wrap_pi(a):
+    return (a + math.pi) % (2.0 * math.pi) - math.pi
 
 
 class ControlPose:
+    """Convert Dracomancer joystick (+ optional operator IMU heading) into a
+    DRAGON FlightNav velocity command.
+
+    direction_mode:
+        none      : joystick axes are used directly as world-frame velocity
+                    (legacy behaviour).
+        yaw       : rotate the horizontal command by the operator heading
+                    (rotation about world vertical) relative to a captured
+                    neutral pose.
+        yaw_pitch : additionally apply the operator pitch (lean) so that
+                    leaning tilts the motion direction.  Roll is ignored.
+        full      : apply the full relative 3D rotation of the operator body.
+    """
+
     def __init__(self):
         rospy.init_node("control_pose")
 
         self.robot_name = rospy.get_param("~robot_name", "dragon")
         self.joy_topic = rospy.get_param("~joy_topic", "/dracomancer/joystick/calibrated")
+        self.imu_topic = rospy.get_param("~imu_topic", "/dracomancer/imu")
         self.rate_hz = rospy.get_param("~rate", 40.0)
         self.wait_after_hover = rospy.get_param("~wait_after_hover", 3.0)
+
+        # ----- navigation target: COG or BASELINK -----
+        nav_target = str(rospy.get_param("~nav_target", "cog")).lower()
+        self.nav_target = FlightNav.BASELINK if nav_target == "baselink" else FlightNav.COG
+
+        # ----- IMU based relative direction control -----
+        # one of: none / yaw / yaw_pitch / full
+        self.direction_mode = str(rospy.get_param("~direction_mode", "yaw")).lower()
+        if self.direction_mode not in ("none", "yaw", "yaw_pitch", "full"):
+            rospy.logwarn("unknown direction_mode '%s', fall back to 'none'", self.direction_mode)
+            self.direction_mode = "none"
+        # IMU mounting correction (operator-body <- IMU board), [rad]
+        mount_rpy = rospy.get_param("~imu_mount_rpy", [0.0, -math.pi / 2.0, 0.0])
+        self.q_mount = quat_from_euler(float(mount_rpy[0]), float(mount_rpy[1]), float(mount_rpy[2]))
+        # recapture neutral heading when the robot starts hovering
+        self.recapture_on_hover = rospy.get_param("~recapture_on_hover", True)
+        self.imu_timeout = rospy.get_param("~imu_timeout", 0.5)
 
         # Msgs
         self.flight_nav = FlightNav()
         self.flight_nav.control_frame = FlightNav.WORLD_FRAME
-        self.flight_nav.target = FlightNav.COG
+        self.flight_nav.target = self.nav_target
         self.flight_nav.pos_xy_nav_mode = FlightNav.POS_VEL_MODE
         self.flight_nav.pos_z_nav_mode = FlightNav.POS_VEL_MODE
         self.flight_nav.yaw_nav_mode = FlightNav.POS_VEL_MODE
@@ -58,6 +152,15 @@ class ControlPose:
         self.robot_landing = False
         self.wait_flag = False
 
+        # IMU state
+        self.q_wo = None                # operator-body orientation in world
+        self.last_imu_stamp = rospy.Time(0)
+        self.neutral_q = None           # captured neutral operator orientation
+        self.neutral_yaw = 0.0
+        self.neutral_pitch = 0.0
+        self.want_recapture = True      # capture neutral on first IMU msg
+        self.prev_hovering = False
+
         # Publishers
         self.nav_pub = rospy.Publisher('/'+self.robot_name + "/uav/nav", FlightNav, queue_size=1)
         self.att_pub = rospy.Publisher('/'+self.robot_name+'/final_target_baselink_rpy', Vector3Stamped, queue_size=1)
@@ -66,10 +169,16 @@ class ControlPose:
         self.robot_flight_state_sub = rospy.Subscriber('/'+self.robot_name+'/flight_state', UInt8, self.robot_flight_state_cb)
         self.robot_pos_sub = rospy.Subscriber('/'+self.robot_name+'/mocap/pose', PoseStamped, self.robot_pos_cb)
         self.js_calibrated_sub = rospy.Subscriber(self.joy_topic, Float32MultiArray, self.joystick_calib_cb, queue_size=1)
+        self.imu_sub = rospy.Subscriber(self.imu_topic, SpinalImu, self.imu_cb, queue_size=1)
+        self.recapture_sub = rospy.Subscriber("~recapture_neutral", Empty, self.recapture_cb, queue_size=1)
 
         # Logger
         rospy.loginfo("robot_name: %s", self.robot_name)
         rospy.loginfo("joy_topic: %s", self.joy_topic)
+        rospy.loginfo("imu_topic: %s", self.imu_topic)
+        rospy.loginfo("direction_mode: %s, nav_target: %s",
+                      self.direction_mode, "baselink" if self.nav_target == FlightNav.BASELINK else "cog")
+        rospy.loginfo("imu_mount_rpy: %s, recapture_on_hover: %s", mount_rpy, self.recapture_on_hover)
 
     def robot_flight_state_cb(self, msg):
         # aerial_robot commonly uses HOVER_STATE=5 and LAND_STATE=6, but keep
@@ -78,9 +187,47 @@ class ControlPose:
         self.robot_landing = int(msg.data) == 6
         if not self.robot_hovering:
             self.wait_flag = False
+        # recapture the neutral heading at the moment hovering starts
+        if self.recapture_on_hover and self.robot_hovering and not self.prev_hovering:
+            self.want_recapture = True
+        self.prev_hovering = self.robot_hovering
 
     def robot_pos_cb(self, msg):
         self.robot_pose = msg
+
+    def recapture_cb(self, msg):
+        self.want_recapture = True
+        rospy.loginfo("neutral heading recapture requested")
+
+    def imu_cb(self, msg):
+        q = quat_normalize([msg.quaternion[0], msg.quaternion[1],
+                            msg.quaternion[2], msg.quaternion[3]])
+        # operator-body orientation in world = q_spinal (board->world) * q_mount
+        self.q_wo = quat_mult(q, self.q_mount)
+        self.last_imu_stamp = rospy.Time.now()
+        if self.want_recapture:
+            self.capture_neutral()
+            self.want_recapture = False
+
+    def imu_ready(self):
+        if self.q_wo is None or self.neutral_q is None:
+            return False
+        return (rospy.Time.now() - self.last_imu_stamp).to_sec() <= self.imu_timeout
+
+    def operator_yaw_pitch(self, q_wo):
+        # operator forward axis (body x) expressed in world
+        fwd = quat_rotate_vec(q_wo, [1.0, 0.0, 0.0])
+        yaw = math.atan2(fwd[1], fwd[0])
+        pitch = math.atan2(-fwd[2], math.hypot(fwd[0], fwd[1]))
+        return yaw, pitch
+
+    def capture_neutral(self):
+        if self.q_wo is None:
+            return
+        self.neutral_q = np.array(self.q_wo)
+        self.neutral_yaw, self.neutral_pitch = self.operator_yaw_pitch(self.q_wo)
+        rospy.loginfo("captured neutral heading: yaw=%.3f pitch=%.3f",
+                      self.neutral_yaw, self.neutral_pitch)
 
     def get_axis(self, data, idx):
         if idx < 0 or idx >= len(data):
@@ -97,6 +244,25 @@ class ControlPose:
     def joystick_calib_cb(self, msg):
         self.latest_axes = list(msg.data)
 
+    def rotate_command(self, body_vec):
+        """Rotate the joystick body command into the world frame using the
+        operator orientation, according to direction_mode."""
+        if self.direction_mode == "none" or not self.imu_ready():
+            return body_vec
+
+        if self.direction_mode == "yaw":
+            yaw, _ = self.operator_yaw_pitch(self.q_wo)
+            return rot_z(wrap_pi(yaw - self.neutral_yaw), body_vec)
+
+        if self.direction_mode == "yaw_pitch":
+            yaw, pitch = self.operator_yaw_pitch(self.q_wo)
+            v = rot_y(pitch - self.neutral_pitch, body_vec)
+            return rot_z(wrap_pi(yaw - self.neutral_yaw), v)
+
+        # full: relative orientation in world since neutral
+        q_rel = quat_mult(self.q_wo, quat_inverse(self.neutral_q))
+        return quat_rotate_vec(q_rel, body_vec)
+
     def make_nav_msg(self):
         if self.latest_axes is None:
             self.flight_nav.target_vel_x = 0.0
@@ -108,9 +274,16 @@ class ControlPose:
         y_cmd = self.get_axis(self.latest_axes, self.axis_y)
         z_cmd = self.get_axis(self.latest_axes, self.axis_z)
 
-        self.flight_nav.target_vel_x = x_cmd * self.xy_vel
-        self.flight_nav.target_vel_y = y_cmd * self.xy_vel
-        self.flight_nav.target_vel_z = z_cmd * self.z_vel
+        # body-frame velocity command from joystick
+        body_vec = np.array([x_cmd * self.xy_vel,
+                             y_cmd * self.xy_vel,
+                             z_cmd * self.z_vel])
+
+        world_vec = self.rotate_command(body_vec)
+
+        self.flight_nav.target_vel_x = float(world_vec[0])
+        self.flight_nav.target_vel_y = float(world_vec[1])
+        self.flight_nav.target_vel_z = float(world_vec[2])
         return self.flight_nav
 
     def limit_pose(self, pos, att):
@@ -136,7 +309,7 @@ class ControlPose:
                 if not self.wait_flag:
                     rospy.sleep(self.wait_after_hover)
                     self.wait_flag = True
-                
+
                 self.make_nav_msg()
                 self.nav_pub.publish(self.flight_nav)
             else:


### PR DESCRIPTION
New features:
- control_pose.py に操作者IMU(spinal/Imu)姿勢を用いた相対移動制御を追加
  - direction_mode で none / yaw / yaw_pitch / full の4方式を切替可能に
  - 起動時・ホバ開始時・手動トピック(~recapture_neutral)で中立向きをキャプチャ する相対方式を採用（spinalのyawドリフト対策）
- nav_target で移動対象を COG(既定) / baselink に切替可能に（FlightNav.target）
- teleoperation.launch に nav_target / direction_mode / imu_topic / imu_mount_roll·pitch·yaw / recapture_neutral_on_hover 引数を追加

Chore:
- package.xml に spinal を run_depend として追記（既存ノードの利用に整合）
- dracomancer パッケージの前提知識をまとめた CLAUDE.md を新規作成

Documentation:
- docs/06_imu_relative_control.md を新規作成（IMU相対移動・移動対象切替を図解）
- docs/01_overview.md, 02_dataflow.md, 05_bringup.md, README.md を実装に合わせ更新

対象ファイル:
- robots/dracomancer/scripts/control_pose.py
- robots/dracomancer/launch/teleoperation.launch
- robots/dracomancer/package.xml
- robots/dracomancer/CLAUDE.md (新規)
- robots/dracomancer/docs/06_imu_relative_control.md (新規)
- robots/dracomancer/docs/01_overview.md
- robots/dracomancer/docs/02_dataflow.md
- robots/dracomancer/docs/05_bringup.md
- robots/dracomancer/docs/README.md

### What is this

Please briefly explain the purpose and the result of this PR.

### Details

Please explain the contribution of this PR in detail.

- commit1:
- commit2:
- commit3:

### TODO

If there is still some work to do. Plase list up as follows:

- [ ] todo1
- [ ] todo2
- [ ] todo3


### Video

Please attach video for better understanding if possible