### PR TITLE
Dracomancer: force/torque volume半径しきい値の常時表示・実行時調整と安全監視の常時稼働

### DIFF
--- a/robots/dracomancer/CLAUDE.md
+++ b/robots/dracomancer/CLAUDE.md
@@ -21,9 +21,10 @@ Dracomancer は **DRAGON を遠隔操作する上肢外骨格（エクソスケ�
 | `scripts/convert_servo_to_joint_states.py` | サーボ tick → rad の関節状態。ID0〜6 を固定マッピング |
 | `scripts/control_position.py` | 操縦桿(+IMU) → DRAGON 移動指令 `/<robot>/uav/nav` |
 | `scripts/control_orientation.py` | 操縦桿 → 姿勢指令 `/<robot>/final_target_baselink_rpy` |
-| `scripts/control_joint_angle.py` | 腕関節 → DRAGON 形状指令 `/<robot>/joints_ctrl`（形状安全付き） |
+| `scripts/control_joint_angle.py` | 腕関節 → DRAGON 形状指令 `/<robot>/joints_ctrl`（安全スケールを購読して抑制） |
+| `scripts/volume_radius_monitor.py` | fc 内接半径の中継・しきい値 pub/sub・安全スケール算出（bringup で常時起動） |
 | `scripts/control_haptic_feedback.py` | 形状抑制量 → Dracomancer 力覚提示 |
-| `launch/bringup.launch` | デバイス本体（URDF/TF/サーボ橋渡し/FC） |
+| `launch/bringup.launch` | デバイス本体（URDF/TF/サーボ橋渡し/FC/安全半径モニタ） |
 | `launch/teleoperation.launch` | 位置・姿勢・関節角制御ノード群 |
 | `launch/haptics.launch` | 力覚提示ノード |
 | `launch/rviz.launch` | GUI PCでRVizだけを起動 |
@@ -71,7 +72,8 @@ Dracomancer は **DRAGON を遠隔操作する上肢外骨格（エクソスケ�
 - `startup`: `startup_pose`（既定 `[0, pi/2, 0, pi/2, 0, pi/2]`）を保持。
 - `precision`: Dracomancer 腕関節を DRAGON 関節へマッピング。
 - `wide`: `wide_hold_pose`（既定 `startup_pose`）を保持し、移動は `control_position.py` に任せる。
-- 形状安全は DRAGON の `/debug/fc_f_min` と `/debug/fc_t_min` からスケールを計算する。
+- 形状安全は **`volume_radius_monitor.py`（bringup.launch）** が DRAGON の `/debug/fc_f_min` と `/debug/fc_t_min` からスケールを計算し `/dracomancer/dragon_shape_safety_scale` に publish。`control_joint_angle.py` はこれを購読して関節指令を抑制する。半径しきい値は `*_volume_radius_threshold` で常時 pub、`*_volume_radius_threshold_cmd`（`[hard_min, min]`）で実行時更新できる。
+- 位置・姿勢・関節角操作はいずれもホバリング（`flight_state>=4`）時のみ出力する（`publish_joints_only_when_hovering` 既定 true）。
 
 ### 数学的に重要な事実（変更時の注意）
 

--- a/robots/dracomancer/docs/dracomancer_system.md
+++ b/robots/dracomancer/docs/dracomancer_system.md
@@ -40,7 +40,8 @@ flowchart TB
 | `convert_servo_to_joint_states.py` | サーボtickをラジアンの関節状態へ変換 | `/dracomancer/servo/states` | `/dracomancer/joint_states` |
 | `control_position.py` | 操縦桿とIMUから DRAGON の速度指令を生成 | joystick, IMU, flight_state | `/dragon/uav/nav` |
 | `control_orientation.py` | 操縦桿から姿勢指令を生成 | joystick, flight_state | `/dragon/final_target_baselink_rpy` |
-| `control_joint_angle.py` | 腕関節から DRAGON の形状指令を生成 | joint_states, fc inradius, flight_state | `/dragon/joints_ctrl`, `/dracomancer/dragon_shape_safety`, `/dracomancer/shape_control_error` |
+| `control_joint_angle.py` | 腕関節から DRAGON の形状指令を生成（安全スケールを購読して抑制） | joint_states, safety_scale, flight_state | `/dragon/joints_ctrl`, `/dracomancer/shape_control_error` |
+| `volume_radius_monitor.py` | fc 内接半径の中継・しきい値 pub/sub・安全スケール算出（bringup.launch で常時起動） | fc inradius, threshold cmd | `/dracomancer/force_volume_radius`, `/dracomancer/torque_volume_radius`, `*_threshold`, `/dracomancer/dragon_shape_safety`, `/dracomancer/dragon_shape_safety_scale` |
 | `control_haptic_feedback.py` | 抑制された形状入力から力覚提示を生成 | joint_states, shape_control_error, mode | `/dracomancer/haptic_torque`, `/servo/target_current` |
 | `publish_fake_joint_states.py` | 実機なしで Dracomancer 関節状態を生成 | `/dracomancer/joint_cmd` | `/dracomancer/joint_states` |
 
@@ -88,7 +89,8 @@ flowchart TB
 | `/dracomancer/joint_states` | `sensor_msgs/JointState` | Dracomancer の腕関節角 |
 | `/dragon/uav/nav` | `aerial_robot_msgs/FlightNav` | DRAGON の速度指令 |
 | `/dragon/joints_ctrl` | `sensor_msgs/JointState` | DRAGON の形状指令 |
-| `/dracomancer/dragon_shape_safety` | `std_msgs/Float64MultiArray` | `[force_inradius, torque_inradius, safety_scale]` |
+| `/dracomancer/dragon_shape_safety` | `std_msgs/Float64MultiArray` | `[force_inradius, torque_inradius, safety_scale]`（`volume_radius_monitor.py` が pub） |
+| `/dracomancer/dragon_shape_safety_scale` | `std_msgs/Float64` | 安全スケール（`control_joint_angle.py` が購読） |
 | `/dracomancer/shape_control_error` | `std_msgs/Float64MultiArray` | 力覚提示用の形状抑制量 `q_des - q_tar` |
 | `/dracomancer/haptic_torque` | `sensor_msgs/JointState` | 安全スケーリングで抑制された入力差から計算した Dracomancer 7関節の提示トルク |
 
@@ -259,21 +261,32 @@ rad = (tick - 2048) * 2*pi / 4096 + offset
 
 ## 形状安全機構
 
-`control_joint_angle.py` は、DRAGON 側の実現可能制御内接半径（feasible control inradius）を参照し、明らかに飛行不可能な形状へ強く押し込まないよう関節指令をスケーリングします。
+形状安全は **2ノード構成**です。
 
-入力となる安全指標:
+- `volume_radius_monitor.py`（**bringup.launch** で常時起動）: DRAGON 側の実現可能制御内接半径（feasible control inradius）を参照し、半径・しきい値・安全スケールを算出して publish。しきい値の実行時更新も受け付ける。
+- `control_joint_angle.py`（teleoperation.launch）: 安全スケールを購読し、明らかに飛行不可能な形状へ強く押し込まないよう関節指令をスケーリングする。
+
+> モニタを bringup 側に置くことで、テレオペレーション（位置・姿勢・関節角操作）がホバリング以外で無効化されていても、安全半径系の pub/sub は動き続けます。
+
+入力となる安全指標（`volume_radius_monitor.py` が購読）:
 
 | トピック | 意味 |
 | --- | --- |
 | `/dragon/debug/fc_f_min` | 力の実現可能内接半径 |
 | `/dragon/debug/fc_t_min` | トルクの実現可能内接半径 |
 
-Dracomancer 側へは以下の topic でも同じ半径を出します。
+Dracomancer 側へは以下の topic でも同じ半径を出します（`volume_radius_monitor.py` が publish）。
 
 | トピック | 型 | 意味 |
 | --- | --- | --- |
 | `/dracomancer/force_volume_radius` | `std_msgs/Float64` | 力の実現可能内接半径 |
 | `/dracomancer/torque_volume_radius` | `std_msgs/Float64` | トルクの実現可能内接半径 |
+| `/dracomancer/force_volume_radius_threshold` | `std_msgs/Float64MultiArray` | 力のしきい値 `[hard_min, min]`（常時 publish） |
+| `/dracomancer/torque_volume_radius_threshold` | `std_msgs/Float64MultiArray` | トルクのしきい値 `[hard_min, min]`（常時 publish） |
+| `/dracomancer/force_volume_radius_threshold_cmd` | `std_msgs/Float64MultiArray` | 力のしきい値 `[hard_min, min]` を実行時に設定（subscribe） |
+| `/dracomancer/torque_volume_radius_threshold_cmd` | `std_msgs/Float64MultiArray` | トルクのしきい値 `[hard_min, min]` を実行時に設定（subscribe） |
+
+しきい値の更新は `hard_min <= min` の場合のみ反映され、要素数が 2 未満や逆転している指令は警告して無視します。
 
 安全スケール:
 
@@ -296,34 +309,48 @@ torque_margin = (torque - torque_hard_min) / (torque_min - torque_hard_min)
 scale = max(min_safety_scale, min(1.0, force_margin, torque_margin))
 ```
 
-スケール適用:
+`volume_radius_monitor.py` は算出した scale を `/dracomancer/dragon_shape_safety_scale`（`std_msgs/Float64`）として publish し、`control_joint_angle.py` がこれを購読します。
 
+スケール適用（`control_joint_angle.py`）:
+
+- 受信した scale が古い（`safety_scale_timeout` 超過）または未受信のときは `missing_safety_scale`（既定 `1.0`＝抑制なし）を使う
 - `scale <= 0`: `safe_pose` へ戻す
 - `0 < scale < 1`: `safe_pose` とマッピング結果を線形補間
 - `scale >= 1`: マッピング結果をそのまま使う
 - 最後に `max_step` で1周期あたりの関節変化量を制限する
 
-送信ゲート:
+送信ゲート（ホバリング以外では位置・姿勢・関節角操作を無効化）:
 
 | 条件 | 既定 | 挙動 |
 | --- | --- | --- |
-| `publish_joints_only_when_hovering` | `false` in `teleoperation.launch` | trueならホバリング前は `/dragon/joints_ctrl` を送らない |
+| `publish_joints_only_when_hovering` | `true` in `teleoperation.launch` | ホバリング前は `/dragon/joints_ctrl` を送らない |
 | `publish_joints_before_device_ready` | `false` | `precision` では false なら Dracomancer 関節状態を受け取るまで送らない |
 
-`control_joint_angle.py` 単体の既定値では `publish_only_when_hovering=true` ですが、`teleoperation.launch` では `false` を渡しています。通常運用の既定値は launch 側を基準にしてください。
+> `control_position.py`（`wide && hovering && !landing`）と `control_orientation.py`（`publish_only_when_hovering` 既定 true）も同様にホバリング時のみ出力します。
 
 主なパラメータ:
 
+`volume_radius_monitor.py`（bringup.launch）:
+
 | パラメータ | 既定 | 説明 |
 | --- | --- | --- |
-| `enable_shape_safety` | `true` | 安全スケーリングの有効化 |
+| `enable_shape_safety` | `true` | 安全スケーリングの有効化（false で scale=1.0 を pub） |
 | `force_inradius_min` | `0.2` | 力余裕の上端 |
 | `force_inradius_hard_min` | `0.1` | 力の危険しきい値 |
 | `torque_inradius_min` | `0.02` | トルク余裕の上端 |
 | `torque_inradius_hard_min` | `0.01` | トルクの危険しきい値 |
-| `missing_inradius_scale` | `1.0` in `teleoperation.launch` | 半径未受信時のスケール |
+| `missing_inradius_scale` | `1.0` | 半径未受信時のスケール |
 | `min_safety_scale` | `0.0` | スケール下限 |
+| `inradius_timeout` | `0.5` | 内接半径の有効期限 [s] |
 | `safety_log_period` | `1.0` | 危険状態・半径・スケールをログ出力する周期 |
+
+`control_joint_angle.py`（teleoperation.launch）:
+
+| パラメータ | 既定 | 説明 |
+| --- | --- | --- |
+| `safety_scale_topic` | `/dracomancer/dragon_shape_safety_scale` | 購読する安全スケール |
+| `safety_scale_timeout` | `0.5` | スケールの有効期限 [s] |
+| `missing_safety_scale` | `1.0` | スケール未受信時の代替値 |
 | `max_step` | `0.04` | 1周期あたりの最大変化量 |
 | `startup_pose` | `[0, pi/2, 0, pi/2, 0, pi/2]` | 立ち上げ時の通常姿勢 |
 | `wide_hold_pose` | `startup_pose` | 広域移動中に保持する形状 |

--- a/robots/dracomancer/launch/bringup.launch
+++ b/robots/dracomancer/launch/bringup.launch
@@ -42,6 +42,21 @@
   <arg name="joint_states_topic" default="/$(arg robot_ns)/joint_states" />
   <arg name="servo_topic"        default="/dracomancer/servo/states" />
 
+  ###########  Force/Torque volume radius monitor  ###########
+  <!-- Controlled articulated aerial robot (DRAGON etc.). Its feasible control
+       inradius (fc_f_min / fc_t_min) drives the shape-safety scale. -->
+  <arg name="controlled_robot_ns"      default="dragon" />
+  <arg name="enable_volume_radius_monitor" default="True" />
+  <arg name="enable_shape_safety"      default="true" />
+  <arg name="missing_inradius_scale"   default="1.0" />
+  <arg name="min_safety_scale"         default="0.0" />
+  <arg name="force_inradius_min"       default="0.2" />
+  <arg name="torque_inradius_min"      default="0.02" />
+  <arg name="force_inradius_hard_min"  default="0.1" />
+  <arg name="torque_inradius_hard_min" default="0.01" />
+  <arg name="inradius_timeout"         default="0.5" />
+  <arg name="safety_log_period"        default="1.0" />
+
   ###########  Robot Model  ###########
   <include file="$(find aerial_robot_model)/launch/aerial_robot_model.launch" >
     <arg name="headless"      value="$(arg model_headless)" />
@@ -97,6 +112,28 @@
       <remap from="joint_states" to="/$(arg robot_ns)/joint_cmd" />
     </node>
   </group>
+
+  ###########  Force/Torque volume radius monitor  ###########
+  <!-- Always-on safety-radius pub/sub: republishes the controlled robot's
+       feasible control inradius, publishes/accepts thresholds, and computes the
+       shape-safety scale consumed by control_joint_angle. -->
+  <node pkg="dracomancer" type="volume_radius_monitor.py" name="volume_radius_monitor"
+        output="screen" if="$(arg enable_volume_radius_monitor)">
+    <param name="robot_name"             value="$(arg controlled_robot_ns)" />
+    <param name="device_ns"              value="/$(arg robot_ns)" />
+    <param name="rate"                   value="40.0" />
+    <param name="force_inradius_topic"   value="/$(arg controlled_robot_ns)/debug/fc_f_min" />
+    <param name="torque_inradius_topic"  value="/$(arg controlled_robot_ns)/debug/fc_t_min" />
+    <param name="force_inradius_min"     value="$(arg force_inradius_min)" />
+    <param name="torque_inradius_min"    value="$(arg torque_inradius_min)" />
+    <param name="force_inradius_hard_min" value="$(arg force_inradius_hard_min)" />
+    <param name="torque_inradius_hard_min" value="$(arg torque_inradius_hard_min)" />
+    <param name="inradius_timeout"       value="$(arg inradius_timeout)" />
+    <param name="enable_shape_safety"    value="$(arg enable_shape_safety)" />
+    <param name="missing_inradius_scale" value="$(arg missing_inradius_scale)" />
+    <param name="min_safety_scale"       value="$(arg min_safety_scale)" />
+    <param name="safety_log_period"      value="$(arg safety_log_period)" />
+  </node>
 
   ###########  Mobile Web Console  ###########
   <include file="$(find aerial_robot_web)/launch/web_console.launch" if="$(arg launch_web_console)">

--- a/robots/dracomancer/launch/teleoperation.launch
+++ b/robots/dracomancer/launch/teleoperation.launch
@@ -15,16 +15,10 @@
   <arg name="servo_topic" default="/dracomancer/servo/states"/>
   <arg name="enable_servo_to_joint_states" default="true"/>
   <arg name="servo_to_joint_states_rate" default="40.0"/>
-  <arg name="enable_shape_safety" default="true"/>
-  <arg name="missing_inradius_scale" default="1.0"/>
-  <arg name="min_safety_scale" default="0.0"/>
-  <arg name="force_inradius_min" default="0.2"/>
-  <arg name="torque_inradius_min" default="0.02"/>
-  <arg name="force_inradius_hard_min" default="0.1"/>
-  <arg name="torque_inradius_hard_min" default="0.01"/>
-  <arg name="safety_log_period" default="1.0"/>
-  <arg name="force_volume_radius_topic" default="/$(arg device_ns)/force_volume_radius"/>
-  <arg name="torque_volume_radius_topic" default="/$(arg device_ns)/torque_volume_radius"/>
+  <!-- Shape-safety scale is produced by volume_radius_monitor in bringup.launch. -->
+  <arg name="safety_scale_topic" default="/$(arg device_ns)/dragon_shape_safety_scale"/>
+  <arg name="safety_scale_timeout" default="0.5"/>
+  <arg name="missing_safety_scale" default="1.0"/>
   <arg name="max_step" default="0.04"/>
   <arg name="joint_limit" default="1.57079632679"/>
   <arg name="capture_neutral_on_first_msg" default="false"/>
@@ -49,7 +43,7 @@
   <arg name="imu_mount_pitch" default="-1.57079632679"/>
   <arg name="imu_mount_yaw" default="0.0"/>
   <arg name="recapture_neutral_on_hover" default="true"/>
-  <arg name="publish_joints_only_when_hovering" default="false"/>
+  <arg name="publish_joints_only_when_hovering" default="true"/>
   <arg name="publish_joints_before_device_ready" default="false"/>
   <arg name="axis_x" default="0"/>
   <arg name="axis_y" default="1"/>
@@ -179,17 +173,8 @@
     <param name="capture_neutral_on_first_msg" value="$(arg capture_neutral_on_first_msg)"/>
     <param name="publish_only_when_hovering" value="$(arg publish_joints_only_when_hovering)"/>
     <param name="publish_before_device_ready" value="$(arg publish_joints_before_device_ready)"/>
-    <param name="force_inradius_topic" value="/$(arg robot_ns)/debug/fc_f_min"/>
-    <param name="torque_inradius_topic" value="/$(arg robot_ns)/debug/fc_t_min"/>
-    <param name="force_inradius_min" value="$(arg force_inradius_min)"/>
-    <param name="torque_inradius_min" value="$(arg torque_inradius_min)"/>
-    <param name="force_inradius_hard_min" value="$(arg force_inradius_hard_min)"/>
-    <param name="torque_inradius_hard_min" value="$(arg torque_inradius_hard_min)"/>
-    <param name="enable_shape_safety" value="$(arg enable_shape_safety)"/>
-    <param name="missing_inradius_scale" value="$(arg missing_inradius_scale)"/>
-    <param name="min_safety_scale" value="$(arg min_safety_scale)"/>
-    <param name="safety_log_period" value="$(arg safety_log_period)"/>
-    <param name="force_volume_radius_topic" value="$(arg force_volume_radius_topic)"/>
-    <param name="torque_volume_radius_topic" value="$(arg torque_volume_radius_topic)"/>
+    <param name="safety_scale_topic" value="$(arg safety_scale_topic)"/>
+    <param name="safety_scale_timeout" value="$(arg safety_scale_timeout)"/>
+    <param name="missing_safety_scale" value="$(arg missing_safety_scale)"/>
   </node>
 </launch>

--- a/robots/dracomancer/scripts/control_joint_angle.py
+++ b/robots/dracomancer/scripts/control_joint_angle.py
@@ -51,45 +51,29 @@ class ControlJoints:
         self.publish_only_when_hovering = rospy.get_param("~publish_only_when_hovering", True)
         self.publish_before_device_ready = rospy.get_param("~publish_before_device_ready", False)
 
-        self.force_inradius_topic = rospy.get_param("~force_inradius_topic", "/" + self.robot_name + "/debug/fc_f_min")
-        self.torque_inradius_topic = rospy.get_param("~torque_inradius_topic", "/" + self.robot_name + "/debug/fc_t_min")
-        self.force_inradius_min = rospy.get_param("~force_inradius_min", 0.2)
-        self.torque_inradius_min = rospy.get_param("~torque_inradius_min", 0.02)
-        self.force_inradius_hard_min = rospy.get_param("~force_inradius_hard_min", 0.1)
-        self.torque_inradius_hard_min = rospy.get_param("~torque_inradius_hard_min", 0.01)
-        self.inradius_timeout = rospy.get_param("~inradius_timeout", 0.5)
-        self.enable_shape_safety = rospy.get_param("~enable_shape_safety", True)
-        self.missing_inradius_scale = rospy.get_param("~missing_inradius_scale", 0.0)
-        self.min_safety_scale = rospy.get_param("~min_safety_scale", 0.0)
-        self.safety_log_period = rospy.get_param("~safety_log_period", 1.0)
-
         self.shape_error_topic = rospy.get_param("~shape_error_topic", self.device_ns + "/shape_control_error")
-        self.force_volume_radius_topic = rospy.get_param(
-            "~force_volume_radius_topic", self.device_ns + "/force_volume_radius")
-        self.torque_volume_radius_topic = rospy.get_param(
-            "~torque_volume_radius_topic", self.device_ns + "/torque_volume_radius")
+        # Shape-safety scale is computed by volume_radius_monitor (bringup.launch) and
+        # consumed here to blend joint commands toward safe_pose. When the scale is
+        # stale/absent, missing_safety_scale (default 1.0 = no limiting) is used.
+        self.safety_scale_topic = rospy.get_param(
+            "~safety_scale_topic", self.device_ns + "/dragon_shape_safety_scale")
+        self.safety_scale_timeout = rospy.get_param("~safety_scale_timeout", 0.5)
+        self.missing_safety_scale = rospy.get_param("~missing_safety_scale", 1.0)
 
         self.latest_device_joints = {}
         self.neutral_device_joints = {}
         self.current_target = list(self.safe_pose)
-        self.force_inradius = None
-        self.torque_inradius = None
-        self.last_inradius_stamp = rospy.Time(0)
+        self.safety_scale_value = None
+        self.last_safety_scale_stamp = rospy.Time(0)
         self.robot_hovering = False
-        self.last_safety_state = None
-        self.last_safety_log_stamp = rospy.Time(0)
 
         # Publisher
         self.joints_ctrl_pub = rospy.Publisher(self.command_topic, JointState, queue_size=10)
-        self.safety_pub = rospy.Publisher("/dracomancer/dragon_shape_safety", Float64MultiArray, queue_size=1)
         self.shape_error_pub = rospy.Publisher(self.shape_error_topic, Float64MultiArray, queue_size=1)
-        self.force_volume_radius_pub = rospy.Publisher(self.force_volume_radius_topic, Float64, queue_size=1)
-        self.torque_volume_radius_pub = rospy.Publisher(self.torque_volume_radius_topic, Float64, queue_size=1)
 
         # Subscriber
         self.device_joint_sub = rospy.Subscriber(self.device_joint_topic, JointState, self.device_joint_cb, queue_size=1)
-        self.force_inradius_sub = rospy.Subscriber(self.force_inradius_topic, Float64, self.force_inradius_cb, queue_size=1)
-        self.torque_inradius_sub = rospy.Subscriber(self.torque_inradius_topic, Float64, self.torque_inradius_cb, queue_size=1)
+        self.safety_scale_sub = rospy.Subscriber(self.safety_scale_topic, Float64, self.safety_scale_cb, queue_size=1)
         self.robot_flight_state_sub = rospy.Subscriber('/' + self.robot_name + '/flight_state', UInt8, self.robot_flight_state_cb, queue_size=1)
         self.mode_sub = rospy.Subscriber(self.mode_topic, String, self.mode_cb, queue_size=1)
 
@@ -104,17 +88,10 @@ class ControlJoints:
                           name, scale, sign, offset)
                                 for name, scale, sign, offset in zip(
                                     self.joint_names, self.scales, self.signs, self.offsets)))
-        rospy.loginfo("force/torque inradius topics: %s, %s", self.force_inradius_topic, self.torque_inradius_topic)
+        rospy.loginfo("safety scale topic: %s (timeout=%.2f, missing=%.3f)",
+                      self.safety_scale_topic, self.safety_scale_timeout, self.missing_safety_scale)
         rospy.loginfo("joint command gating: only_when_hovering=%s, before_device_ready=%s",
                       self.publish_only_when_hovering, self.publish_before_device_ready)
-        rospy.loginfo(
-            "shape safety: enable=%s, missing_scale=%.3f, min_scale=%.3f, force=(%.3f/%.3f), torque=(%.3f/%.3f)",
-            self.enable_shape_safety, self.missing_inradius_scale, self.min_safety_scale,
-            self.force_inradius_hard_min, self.force_inradius_min,
-            self.torque_inradius_hard_min, self.torque_inradius_min)
-        rospy.loginfo("shape safety debug topics: safety=%s, shape_error=%s, force_radius=%s, torque_radius=%s",
-                      "/dracomancer/dragon_shape_safety", self.shape_error_topic,
-                      self.force_volume_radius_topic, self.torque_volume_radius_topic)
 
     def mode_cb(self, msg):
         mode = str(msg.data).strip().lower()
@@ -139,82 +116,21 @@ class ControlJoints:
                 }
                 rospy.loginfo("Captured dracomancer neutral joints for DRAGON mapping")
 
-    def force_inradius_cb(self, msg):
-        self.force_inradius = float(msg.data)
-        self.last_inradius_stamp = rospy.Time.now()
-
-    def torque_inradius_cb(self, msg):
-        self.torque_inradius = float(msg.data)
-        self.last_inradius_stamp = rospy.Time.now()
+    def safety_scale_cb(self, msg):
+        self.safety_scale_value = float(msg.data)
+        self.last_safety_scale_stamp = rospy.Time.now()
 
     def robot_flight_state_cb(self, msg):
         self.robot_hovering = int(msg.data) >= 4
 
-    def inradius_ready(self):
-        if self.force_inradius is None or self.torque_inradius is None:
-            return False
-        return (rospy.Time.now() - self.last_inradius_stamp).to_sec() <= self.inradius_timeout
-
     def safety_scale(self):
-        if not self.enable_shape_safety:
-            return 1.0
-        if not self.inradius_ready():
-            return max(0.0, min(1.0, self.missing_inradius_scale))
-        if (self.force_inradius <= self.force_inradius_hard_min or
-                self.torque_inradius <= self.torque_inradius_hard_min):
-            return max(0.0, min(1.0, self.min_safety_scale))
-        force_margin = (self.force_inradius - self.force_inradius_hard_min) / max(
-            self.force_inradius_min - self.force_inradius_hard_min, 1e-6)
-        torque_margin = (self.torque_inradius - self.torque_inradius_hard_min) / max(
-            self.torque_inradius_min - self.torque_inradius_hard_min, 1e-6)
-        return max(self.min_safety_scale, min(1.0, force_margin, torque_margin))
-
-    def safety_state(self, scale=None):
-        if not self.enable_shape_safety:
-            return "disabled"
-        if not self.inradius_ready():
-            return "missing_inradius"
-        if (self.force_inradius <= self.force_inradius_hard_min or
-                self.torque_inradius <= self.torque_inradius_hard_min):
-            return "danger"
-        if scale is None:
-            scale = self.safety_scale()
-        if scale < 1.0:
-            return "warning"
-        return "safe"
-
-    def log_safety_state(self):
-        scale = self.safety_scale()
-        state = self.safety_state(scale)
-        force_radius = self.force_inradius if self.force_inradius is not None else -1.0
-        torque_radius = self.torque_inradius if self.torque_inradius is not None else -1.0
-        can_publish = self.can_publish_joint_command()
-
-        message = (
-            "shape_safety state=%s mode=%s can_publish=%s "
-            "force_volume_radius=%.4f torque_volume_radius=%.4f safety_scale=%.3f "
-            "thresholds force(hard/min)=%.4f/%.4f torque(hard/min)=%.4f/%.4f"
-        ) % (
-            state, self.teleop_mode, can_publish,
-            force_radius, torque_radius, scale,
-            self.force_inradius_hard_min, self.force_inradius_min,
-            self.torque_inradius_hard_min, self.torque_inradius_min,
-        )
-
-        if state != self.last_safety_state:
-            self.last_safety_state = state
-
-        now = rospy.Time.now()
-        if self.safety_log_period > 0.0:
-            elapsed = (now - self.last_safety_log_stamp).to_sec()
-            if elapsed < self.safety_log_period:
-                return
-        self.last_safety_log_stamp = now
-
-        if state in ("danger", "missing_inradius"):
-            rospy.logwarn(message)
-        else:
-            rospy.loginfo(message)
+        # Use the latest scale from volume_radius_monitor; fall back to
+        # missing_safety_scale when it is absent or stale.
+        if self.safety_scale_value is None:
+            return max(0.0, min(1.0, self.missing_safety_scale))
+        if (rospy.Time.now() - self.last_safety_scale_stamp).to_sec() > self.safety_scale_timeout:
+            return max(0.0, min(1.0, self.missing_safety_scale))
+        return max(0.0, min(1.0, self.safety_scale_value))
 
     def mapped_target(self):
         if not self.latest_device_joints:
@@ -283,29 +199,12 @@ class ControlJoints:
             return False
         return True
 
-    def publish_safety(self):
-        force_radius = float(self.force_inradius if self.force_inradius is not None else -1.0)
-        torque_radius = float(self.torque_inradius if self.torque_inradius is not None else -1.0)
-
-        msg = Float64MultiArray()
-        msg.data = [
-            force_radius,
-            torque_radius,
-            float(self.safety_scale()),
-        ]
-        self.safety_pub.publish(msg)
-
-        self.force_volume_radius_pub.publish(Float64(force_radius))
-        self.torque_volume_radius_pub.publish(Float64(torque_radius))
-        self.log_safety_state()
-
     def main(self):
         rate = rospy.Rate(self.rate_hz)
 
         while not rospy.is_shutdown():
             if self.can_publish_joint_command():
                 self.joints_ctrl_pub.publish(self.make_joint_msg())
-            self.publish_safety()
             rate.sleep()
 
 

--- a/robots/dracomancer/scripts/volume_radius_monitor.py
+++ b/robots/dracomancer/scripts/volume_radius_monitor.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""Force/Torque volume radius monitor.
+
+Republishes DRAGON's feasible control inradius (fc_f_min / fc_t_min) as
+Dracomancer volume-radius topics, publishes the safety thresholds, accepts
+runtime threshold updates, and computes the shape-safety scale used to limit
+joint commands.
+
+This runs as part of the device bringup (bringup.launch) so that the safety
+monitoring keeps publishing even while teleoperation (position / orientation /
+joint-angle control) is disabled, e.g. when DRAGON is not hovering.
+"""
+
+import rospy
+from std_msgs.msg import Float64, Float64MultiArray
+
+
+class VolumeRadiusMonitor:
+    def __init__(self):
+        rospy.init_node("volume_radius_monitor")
+
+        self.robot_name = rospy.get_param("~robot_name", "dragon")
+        self.device_ns = rospy.get_param("~device_ns", "/dracomancer").rstrip("/")
+        self.rate_hz = rospy.get_param("~rate", 40.0)
+
+        # Input: DRAGON feasible control inradius (force / torque).
+        self.force_inradius_topic = rospy.get_param("~force_inradius_topic", "/" + self.robot_name + "/debug/fc_f_min")
+        self.torque_inradius_topic = rospy.get_param("~torque_inradius_topic", "/" + self.robot_name + "/debug/fc_t_min")
+
+        # Thresholds: [hard_min, min]. hard_min = danger, min = upper end of margin.
+        self.force_inradius_min = rospy.get_param("~force_inradius_min", 0.2)
+        self.torque_inradius_min = rospy.get_param("~torque_inradius_min", 0.02)
+        self.force_inradius_hard_min = rospy.get_param("~force_inradius_hard_min", 0.1)
+        self.torque_inradius_hard_min = rospy.get_param("~torque_inradius_hard_min", 0.01)
+
+        self.inradius_timeout = rospy.get_param("~inradius_timeout", 0.5)
+        self.enable_shape_safety = rospy.get_param("~enable_shape_safety", True)
+        self.missing_inradius_scale = rospy.get_param("~missing_inradius_scale", 1.0)
+        self.min_safety_scale = rospy.get_param("~min_safety_scale", 0.0)
+        self.safety_log_period = rospy.get_param("~safety_log_period", 1.0)
+
+        # Output topics.
+        self.shape_safety_topic = rospy.get_param("~shape_safety_topic", self.device_ns + "/dragon_shape_safety")
+        self.safety_scale_topic = rospy.get_param("~safety_scale_topic", self.device_ns + "/dragon_shape_safety_scale")
+        self.force_volume_radius_topic = rospy.get_param(
+            "~force_volume_radius_topic", self.device_ns + "/force_volume_radius")
+        self.torque_volume_radius_topic = rospy.get_param(
+            "~torque_volume_radius_topic", self.device_ns + "/torque_volume_radius")
+        self.force_volume_radius_threshold_topic = rospy.get_param(
+            "~force_volume_radius_threshold_topic", self.device_ns + "/force_volume_radius_threshold")
+        self.torque_volume_radius_threshold_topic = rospy.get_param(
+            "~torque_volume_radius_threshold_topic", self.device_ns + "/torque_volume_radius_threshold")
+        self.force_volume_radius_threshold_cmd_topic = rospy.get_param(
+            "~force_volume_radius_threshold_cmd_topic", self.device_ns + "/force_volume_radius_threshold_cmd")
+        self.torque_volume_radius_threshold_cmd_topic = rospy.get_param(
+            "~torque_volume_radius_threshold_cmd_topic", self.device_ns + "/torque_volume_radius_threshold_cmd")
+
+        self.force_inradius = None
+        self.torque_inradius = None
+        self.last_inradius_stamp = rospy.Time(0)
+        self.last_safety_state = None
+        self.last_safety_log_stamp = rospy.Time(0)
+
+        # Publishers.
+        self.shape_safety_pub = rospy.Publisher(self.shape_safety_topic, Float64MultiArray, queue_size=1)
+        self.safety_scale_pub = rospy.Publisher(self.safety_scale_topic, Float64, queue_size=1)
+        self.force_volume_radius_pub = rospy.Publisher(self.force_volume_radius_topic, Float64, queue_size=1)
+        self.torque_volume_radius_pub = rospy.Publisher(self.torque_volume_radius_topic, Float64, queue_size=1)
+        self.force_volume_radius_threshold_pub = rospy.Publisher(
+            self.force_volume_radius_threshold_topic, Float64MultiArray, queue_size=1)
+        self.torque_volume_radius_threshold_pub = rospy.Publisher(
+            self.torque_volume_radius_threshold_topic, Float64MultiArray, queue_size=1)
+
+        # Subscribers.
+        rospy.Subscriber(self.force_inradius_topic, Float64, self.force_inradius_cb, queue_size=1)
+        rospy.Subscriber(self.torque_inradius_topic, Float64, self.torque_inradius_cb, queue_size=1)
+        rospy.Subscriber(self.force_volume_radius_threshold_cmd_topic, Float64MultiArray,
+                         self.force_volume_radius_threshold_cmd_cb, queue_size=1)
+        rospy.Subscriber(self.torque_volume_radius_threshold_cmd_topic, Float64MultiArray,
+                         self.torque_volume_radius_threshold_cmd_cb, queue_size=1)
+
+        rospy.loginfo("volume_radius_monitor: robot=%s, inradius topics: %s, %s",
+                      self.robot_name, self.force_inradius_topic, self.torque_inradius_topic)
+        rospy.loginfo(
+            "shape safety: enable=%s, missing_scale=%.3f, min_scale=%.3f, force=(%.3f/%.3f), torque=(%.3f/%.3f)",
+            self.enable_shape_safety, self.missing_inradius_scale, self.min_safety_scale,
+            self.force_inradius_hard_min, self.force_inradius_min,
+            self.torque_inradius_hard_min, self.torque_inradius_min)
+        rospy.loginfo("safety scale topic: %s", self.safety_scale_topic)
+
+    def force_inradius_cb(self, msg):
+        self.force_inradius = float(msg.data)
+        self.last_inradius_stamp = rospy.Time.now()
+
+    def torque_inradius_cb(self, msg):
+        self.torque_inradius = float(msg.data)
+        self.last_inradius_stamp = rospy.Time.now()
+
+    @staticmethod
+    def parse_threshold_cmd(msg, label):
+        # Expect [hard_min, min]; hard_min must not exceed min.
+        if len(msg.data) < 2:
+            rospy.logwarn("ignore %s threshold cmd: need [hard_min, min], got %d value(s)",
+                          label, len(msg.data))
+            return None
+        hard_min = float(msg.data[0])
+        soft_min = float(msg.data[1])
+        if hard_min > soft_min:
+            rospy.logwarn("ignore %s threshold cmd: hard_min(%.4f) > min(%.4f)",
+                          label, hard_min, soft_min)
+            return None
+        return hard_min, soft_min
+
+    def force_volume_radius_threshold_cmd_cb(self, msg):
+        parsed = self.parse_threshold_cmd(msg, "force")
+        if parsed is None:
+            return
+        self.force_inradius_hard_min, self.force_inradius_min = parsed
+        rospy.loginfo("force volume radius threshold updated: hard_min=%.4f min=%.4f",
+                      self.force_inradius_hard_min, self.force_inradius_min)
+
+    def torque_volume_radius_threshold_cmd_cb(self, msg):
+        parsed = self.parse_threshold_cmd(msg, "torque")
+        if parsed is None:
+            return
+        self.torque_inradius_hard_min, self.torque_inradius_min = parsed
+        rospy.loginfo("torque volume radius threshold updated: hard_min=%.4f min=%.4f",
+                      self.torque_inradius_hard_min, self.torque_inradius_min)
+
+    def inradius_ready(self):
+        if self.force_inradius is None or self.torque_inradius is None:
+            return False
+        return (rospy.Time.now() - self.last_inradius_stamp).to_sec() <= self.inradius_timeout
+
+    def safety_scale(self):
+        if not self.enable_shape_safety:
+            return 1.0
+        if not self.inradius_ready():
+            return max(0.0, min(1.0, self.missing_inradius_scale))
+        if (self.force_inradius <= self.force_inradius_hard_min or
+                self.torque_inradius <= self.torque_inradius_hard_min):
+            return max(0.0, min(1.0, self.min_safety_scale))
+        force_margin = (self.force_inradius - self.force_inradius_hard_min) / max(
+            self.force_inradius_min - self.force_inradius_hard_min, 1e-6)
+        torque_margin = (self.torque_inradius - self.torque_inradius_hard_min) / max(
+            self.torque_inradius_min - self.torque_inradius_hard_min, 1e-6)
+        return max(self.min_safety_scale, min(1.0, force_margin, torque_margin))
+
+    def safety_state(self, scale=None):
+        if not self.enable_shape_safety:
+            return "disabled"
+        if not self.inradius_ready():
+            return "missing_inradius"
+        if (self.force_inradius <= self.force_inradius_hard_min or
+                self.torque_inradius <= self.torque_inradius_hard_min):
+            return "danger"
+        if scale is None:
+            scale = self.safety_scale()
+        if scale < 1.0:
+            return "warning"
+        return "safe"
+
+    def log_safety_state(self, scale, state, force_radius, torque_radius):
+        message = (
+            "shape_safety state=%s "
+            "force_volume_radius=%.4f torque_volume_radius=%.4f safety_scale=%.3f "
+            "thresholds force(hard/min)=%.4f/%.4f torque(hard/min)=%.4f/%.4f"
+        ) % (
+            state, force_radius, torque_radius, scale,
+            self.force_inradius_hard_min, self.force_inradius_min,
+            self.torque_inradius_hard_min, self.torque_inradius_min,
+        )
+
+        if state != self.last_safety_state:
+            self.last_safety_state = state
+
+        now = rospy.Time.now()
+        if self.safety_log_period > 0.0:
+            if (now - self.last_safety_log_stamp).to_sec() < self.safety_log_period:
+                return
+        self.last_safety_log_stamp = now
+
+        if state in ("danger", "missing_inradius"):
+            rospy.logwarn(message)
+        else:
+            rospy.loginfo(message)
+
+    def publish(self):
+        force_radius = float(self.force_inradius if self.force_inradius is not None else -1.0)
+        torque_radius = float(self.torque_inradius if self.torque_inradius is not None else -1.0)
+        scale = float(self.safety_scale())
+        state = self.safety_state(scale)
+
+        self.shape_safety_pub.publish(
+            Float64MultiArray(data=[force_radius, torque_radius, scale]))
+        self.safety_scale_pub.publish(Float64(scale))
+        self.force_volume_radius_pub.publish(Float64(force_radius))
+        self.torque_volume_radius_pub.publish(Float64(torque_radius))
+        self.force_volume_radius_threshold_pub.publish(
+            Float64MultiArray(data=[float(self.force_inradius_hard_min), float(self.force_inradius_min)]))
+        self.torque_volume_radius_threshold_pub.publish(
+            Float64MultiArray(data=[float(self.torque_inradius_hard_min), float(self.torque_inradius_min)]))
+        self.log_safety_state(scale, state, force_radius, torque_radius)
+
+    def main(self):
+        rate = rospy.Rate(self.rate_hz)
+        while not rospy.is_shutdown():
+            self.publish()
+            rate.sleep()
+
+
+if __name__ == "__main__":
+    try:
+        VolumeRadiusMonitor().main()
+    except rospy.ROSInterruptException:
+        pass
+    except Exception as e:
+        rospy.logerr(str(e))


### PR DESCRIPTION
## 何ができるようになったか（ユーザー視点）

### force/torque volume 半径のしきい値を常時確認・実行時に調整できる
- DRAGON の操縦中、力・トルクの volume 半径しきい値が常に表示（publish）されるようになりました。
  - `/dracomancer/force_volume_radius_threshold`（`[hard_min, min]`）
  - `/dracomancer/torque_volume_radius_threshold`（`[hard_min, min]`）
- 実行を止めずに、しきい値を上書きできるようになりました。
  - 例: `rostopic pub -1 /dracomancer/force_volume_radius_threshold_cmd std_msgs/Float64MultiArray "data: [0.12, 0.25]"`
  - `hard_min <= min` の指令のみ反映し、不正な指令（要素不足・逆転）は警告して無視します。

### ホバリング以外では遠隔操作が無効に
- DRAGON がホバリングしていない間は、**位置・姿勢・関節角の操作指令を送らない**ようになりました（離陸前・着陸後に意図しない指令が出ません）。

### 安全半径の監視がデバイス起動中ずっと動く
- 安全半径系（半径の中継・しきい値・安全スケール算出）を独立ノード `volume_radius_monitor` として `bringup.launch` 側へ移しました。
- これにより、遠隔操作（teleoperation）が無効化されている間も安全半径の表示・しきい値設定は動き続けます。
- 形状安全の抑制挙動（安全姿勢への補間）自体は従来どおりです。

## 確認したこと
- 全スクリプトの `py_compile` 成功
- `roslaunch --files` で `bringup.launch` / `teleoperation.launch` のパース成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)