### PR TITLE
Dracomancer: dragon半径の再pub停止と予測フィージビリティ・ゲート

### DIFF
--- a/aerial_robot_web/www/app.js
+++ b/aerial_robot_web/www/app.js
@@ -837,7 +837,9 @@
     const dracomancerViewerApiRef = React.useRef(null);
     const [dragonNs, setDragonNs] = React.useState('/dragon');
     const [flightState, setFlightState] = React.useState(null);
-    const [shapeSafety, setShapeSafety] = React.useState(null);
+    const [forceRadius, setForceRadius] = React.useState(null);
+    const [torqueRadius, setTorqueRadius] = React.useState(null);
+    const [safetyScale, setSafetyScale] = React.useState(null);
     const [joyAxes, setJoyAxes] = React.useState(null);
     const [deviceJoints, setDeviceJoints] = React.useState(null);
     const [dragonJoints, setDragonJoints] = React.useState(null);
@@ -856,14 +858,34 @@
       return () => topic.unsubscribe();
     }, [ros, connected, dragonNs]);
 
+    // Inradius comes straight from the controlled robot (dragon); dracomancer
+    // does not republish it. Only the dracomancer-computed safety scale is taken
+    // from the device namespace.
     React.useEffect(() => {
-      setShapeSafety(null);
+      setForceRadius(null);
+      setTorqueRadius(null);
+      if (!ros || !connected || !window.ROSLIB) return undefined;
+      const forceTopic = new window.ROSLIB.Topic({
+        ros, name: nsJoin(dragonNs, 'debug/fc_f_min'),
+        messageType: 'std_msgs/Float64', throttle_rate: 100, queue_length: 1,
+      });
+      const torqueTopic = new window.ROSLIB.Topic({
+        ros, name: nsJoin(dragonNs, 'debug/fc_t_min'),
+        messageType: 'std_msgs/Float64', throttle_rate: 100, queue_length: 1,
+      });
+      forceTopic.subscribe((msg) => setForceRadius(Number(msg.data)));
+      torqueTopic.subscribe((msg) => setTorqueRadius(Number(msg.data)));
+      return () => { forceTopic.unsubscribe(); torqueTopic.unsubscribe(); };
+    }, [ros, connected, dragonNs]);
+
+    React.useEffect(() => {
+      setSafetyScale(null);
       if (!ros || !connected || !window.ROSLIB) return undefined;
       const topic = new window.ROSLIB.Topic({
-        ros, name: nsJoin(deviceNs, 'dragon_shape_safety'),
-        messageType: 'std_msgs/Float64MultiArray', throttle_rate: 100, queue_length: 1,
+        ros, name: nsJoin(deviceNs, 'dragon_shape_safety_scale'),
+        messageType: 'std_msgs/Float64', throttle_rate: 100, queue_length: 1,
       });
-      topic.subscribe((msg) => setShapeSafety(msg.data || []));
+      topic.subscribe((msg) => setSafetyScale(Number(msg.data)));
       return () => topic.unsubscribe();
     }, [ros, connected, deviceNs]);
 
@@ -964,7 +986,6 @@
       : isHovering ? `${flightState} (hovering)`
       : `${flightState} (grounded)`;
 
-    const safetyScale = shapeSafety != null && shapeSafety.length > 2 ? Number(shapeSafety[2]) : null;
     const safetyCls = safetyScale == null ? '' : safetyScale >= 0.7 ? 'ok' : safetyScale >= 0.3 ? 'warn' : 'bad';
 
     const jointRow = (name, pos, maxRad) => {
@@ -1007,11 +1028,11 @@
             ),
             e('div', { className: 'drac-metric' },
               e('span', { className: 'label' }, 'Force Inradius'),
-              e('span', { className: 'value' }, shapeSafety != null && shapeSafety.length > 0 ? formatNumber(shapeSafety[0]) : '—'),
+              e('span', { className: 'value' }, forceRadius != null ? formatNumber(forceRadius) : '—'),
             ),
             e('div', { className: 'drac-metric' },
               e('span', { className: 'label' }, 'Torque Inradius'),
-              e('span', { className: 'value' }, shapeSafety != null && shapeSafety.length > 1 ? formatNumber(shapeSafety[1]) : '—'),
+              e('span', { className: 'value' }, torqueRadius != null ? formatNumber(torqueRadius) : '—'),
             ),
           ),
           safetyScale != null && e('div', { className: 'drac-gauge-row' },

--- a/robots/dracomancer/CLAUDE.md
+++ b/robots/dracomancer/CLAUDE.md
@@ -9,8 +9,9 @@ Dracomancer は **DRAGON を遠隔操作する上肢外骨格（エクソスケ�
 オペレータの腕の関節角と操縦桿、背中の IMU を読み取り、DRAGON の
 **移動指令（FlightNav）** と **形状指令（joints_ctrl）** に変換する。
 
-- 実体は `scripts/` 配下の **Python ノード**。
-- `src/`（`dracomancer.cpp`, `model/`, `control/`）と `include/` は**現状すべて空のプレースホルダ**。
+- 実体は主に `scripts/` 配下の **Python ノード**。
+- 例外として `src/shape_feasibility_node.cpp` は実装済みの C++ サービスノード（pluginlib で DRAGON モデルを読み込み fc 半径を予測）。
+- `src/` の `dracomancer.cpp`, `model/`, `control/` と `include/` は**空のプレースホルダ**。
   C++ プラグイン（`plugins/*.xml`）は宣言のみで中身がない。安易に「実装済み」と扱わないこと。
 
 ## ファイル構成と役割
@@ -21,8 +22,9 @@ Dracomancer は **DRAGON を遠隔操作する上肢外骨格（エクソスケ�
 | `scripts/convert_servo_to_joint_states.py` | サーボ tick → rad の関節状態。ID0〜6 を固定マッピング |
 | `scripts/control_position.py` | 操縦桿(+IMU) → DRAGON 移動指令 `/<robot>/uav/nav` |
 | `scripts/control_orientation.py` | 操縦桿 → 姿勢指令 `/<robot>/final_target_baselink_rpy` |
-| `scripts/control_joint_angle.py` | 腕関節 → DRAGON 形状指令 `/<robot>/joints_ctrl`（安全スケールを購読して抑制） |
-| `scripts/volume_radius_monitor.py` | fc 内接半径の中継・しきい値 pub/sub・安全スケール算出（bringup で常時起動） |
+| `scripts/control_joint_angle.py` | 腕関節 → DRAGON 形状指令 `/<robot>/joints_ctrl`（候補姿勢のフィージビリティで変形可否を判定） |
+| `src/shape_feasibility_node.cpp` | 候補リンク角の force/torque volume 半径を DRAGON モデルで予測するサービス（C++） |
+| `scripts/volume_radius_monitor.py` | しきい値 pub/sub・ライブ安全スケール算出（bringup で常時起動） |
 | `scripts/control_haptic_feedback.py` | 形状抑制量 → Dracomancer 力覚提示 |
 | `launch/bringup.launch` | デバイス本体（URDF/TF/サーボ橋渡し/FC/安全半径モニタ） |
 | `launch/teleoperation.launch` | 位置・姿勢・関節角制御ノード群 |
@@ -70,10 +72,12 @@ Dracomancer は **DRAGON を遠隔操作する上肢外骨格（エクソスケ�
 ## control_joint_angle.py（形状制御）の設計
 
 - `startup`: `startup_pose`（既定 `[0, pi/2, 0, pi/2, 0, pi/2]`）を保持。
-- `precision`: Dracomancer 腕関節を DRAGON 関節へマッピング。
+- `precision`: Dracomancer 腕関節を DRAGON 関節へマッピングし、**候補姿勢のフィージビリティで変形可否を判定**する。
 - `wide`: `wide_hold_pose`（既定 `startup_pose`）を保持し、移動は `control_position.py` に任せる。
-- 形状安全は **`volume_radius_monitor.py`（bringup.launch）** が DRAGON の `/debug/fc_f_min` と `/debug/fc_t_min` からスケールを計算し `/dracomancer/dragon_shape_safety_scale` に publish。`control_joint_angle.py` はこれを購読して関節指令を抑制する。半径しきい値は `*_volume_radius_threshold` で常時 pub、`*_volume_radius_threshold_cmd`（`[hard_min, min]`）で実行時更新できる。
+- **予測フィージビリティ・ゲート（主機構）**: 候補 DRAGON 形状を `shape_feasibility_node`（C++、`dragon/full_vectoring_robot_model` を pluginlib で読み込み、`ns=dragon` で起動）の `check_shape` サービスに渡し `fc_f_min`/`fc_t_min` を予測。force・torque 両方が下限しきい値以上なら変形（採用・記憶）、未満／サービス失敗なら直前可行姿勢で停止。下限しきい値は `*_volume_radius_threshold`（`[hard_min, min]` の `hard_min`）を購読、未受信時は `force_radius_threshold`/`torque_radius_threshold` パラメータ。
+- **ライブ監視（情報提供）**: `volume_radius_monitor.py`（bringup.launch）が実機現在状態の fc からライブスケールを `/dracomancer/dragon_shape_safety_scale` に publish（web UI 用、ゲートとは独立）。しきい値の所有・pub/sub もここ。
 - 位置・姿勢・関節角操作はいずれもホバリング（`flight_state>=4`）時のみ出力する（`publish_joints_only_when_hovering` 既定 true）。
+- `shape_feasibility_node` は DRAGON のモデル/パラメータを使うため **DRAGON 起動が前提**。`dragon` を run_depend に追加済み。
 
 ### 数学的に重要な事実（変更時の注意）
 

--- a/robots/dracomancer/CMakeLists.txt
+++ b/robots/dracomancer/CMakeLists.txt
@@ -9,9 +9,10 @@ add_compile_options(-std=c++17)
 # 依存パッケージを解決
 # 以後 ${catkin_LIBRARIES}, ${catkin_INCLUDE_DIRS} が使える
 find_package(catkin REQUIRED COMPONENTS
-  # roscpp
+  roscpp
   # rospy
   std_msgs
+  sensor_msgs
   aerial_robot_control
   aerial_robot_estimation
   aerial_robot_model
@@ -26,11 +27,21 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(Eigen3 REQUIRED)
 find_package(NLopt REQUIRED)
 
+# サービス定義
+add_service_files(
+  FILES
+  ShapeFeasibility.srv
+)
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
+
 # 下流パッケージへ「このパッケージは何を公開するか」を宣言
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES dracomancer
-  CATKIN_DEPENDS roscpp std_msgs aerial_robot_control aerial_robot_model aerial_robot_msgs pluginlib diagnostic_msgs geometry_msgs message_runtime
+  CATKIN_DEPENDS roscpp std_msgs sensor_msgs aerial_robot_control aerial_robot_model aerial_robot_msgs pluginlib diagnostic_msgs geometry_msgs message_runtime
 )
 
 ###########
@@ -52,9 +63,17 @@ target_link_libraries(dracomancer_controllib ${catkin_LIBRARIES} ${NLOPT_LIBRARI
 add_library(dracomancer_model src/model/dracomancer_model.cpp)
 target_link_libraries(dracomancer_model ${catkin_LIBRARIES})
 
+# 候補姿勢の force/torque volume 半径を予測するサービスノード
+add_executable(shape_feasibility_node src/shape_feasibility_node.cpp)
+add_dependencies(shape_feasibility_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(shape_feasibility_node ${catkin_LIBRARIES})
+
 # install（他パッケージから使えるように）
 install(TARGETS dracomancer_controllib
   DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
+install(TARGETS shape_feasibility_node
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 install(DIRECTORY config plugins launch scripts
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}

--- a/robots/dracomancer/README.md
+++ b/robots/dracomancer/README.md
@@ -253,18 +253,16 @@ rostopic echo /dragon/joints_ctrl
 Check the shape safety state:
 
 ```bash
-rostopic echo /dracomancer/dragon_shape_safety
-rostopic echo /dracomancer/force_volume_radius
-rostopic echo /dracomancer/torque_volume_radius
+rostopic echo /dracomancer/dragon_shape_safety_scale   # safety scale (0..1)
+rostopic echo /dragon/debug/fc_f_min                    # force inradius (from dragon)
+rostopic echo /dragon/debug/fc_t_min                    # torque inradius (from dragon)
 ```
 
-The safety message contains:
+The safety scale is computed by `volume_radius_monitor.py` (started in
+`bringup.launch`). The raw inradius is **not** republished under the
+`dracomancer` namespace — subscribe to the dragon topics directly.
 
-```text
-[force_inradius, torque_inradius, safety_scale]
-```
-
-`control_joint_angle.py` also logs whether the current shape is `safe`,
+`volume_radius_monitor.py` also logs whether the current shape is `safe`,
 `warning`, `danger`, or waiting for inradius input. The log period is controlled
 by `safety_log_period`.
 

--- a/robots/dracomancer/README.md
+++ b/robots/dracomancer/README.md
@@ -170,25 +170,23 @@ roslaunch dracomancer teleoperation.launch
 This starts in `startup` mode.  Switch to `wide` for joystick/IMU movement, or
 `precision` for arm-to-DRAGON shape mapping.
 
-For simulation where falling is acceptable and infeasible-pose rejection is too
-strong:
+For simulation where falling is acceptable and the predictive feasibility gate
+is too strong (deform freely, no rejection):
 
 ```bash
 roslaunch dracomancer teleoperation.launch \
-  enable_shape_safety:=false \
+  enable_feasibility_gate:=false \
   publish_joints_only_when_hovering:=true \
   publish_joints_before_device_ready:=false \
   max_step:=0.03
 ```
 
-For partial safety instead of disabling it completely:
+To keep the gate but relax the lower thresholds:
 
 ```bash
 roslaunch dracomancer teleoperation.launch \
-  min_safety_scale:=0.5 \
-  missing_inradius_scale:=0.5 \
-  force_inradius_min:=0.05 \
-  torque_inradius_min:=0.005 \
+  force_radius_threshold:=0.05 \
+  torque_radius_threshold:=0.005 \
   max_step:=0.03
 ```
 
@@ -223,11 +221,14 @@ roslaunch dracomancer haptics.launch \
   `/dracomancer/servo/states`.
 - `device_joint_topic`: Dracomancer joint state topic. Default:
   `/dracomancer/joint_states`.
-- `enable_shape_safety`: enables feasible-control inradius based joint command
-  scaling.
-- `missing_inradius_scale`: command scale used before `/dragon/debug/fc_*` is
-  available.
-- `min_safety_scale`: lower bound for joint command scale when inradius is low.
+- `enable_feasibility_gate`: enables the predictive shape-feasibility gate in
+  precision mode (candidate shape is evaluated before being sent).
+- `feasibility_service`: predicted-radius service name. Default:
+  `/dragon/shape_feasibility/check_shape`.
+- `force_radius_threshold` / `torque_radius_threshold`: lower bounds for the
+  predicted force / torque volume radius (fallback when the threshold topics are
+  not received).
+- `feasibility_rate`: how often the candidate shape is re-evaluated (Hz).
 - `max_step`: max joint target change per control cycle.
 - `publish_joints_only_when_hovering`: publishes `/dragon/joints_ctrl` only when
   DRAGON is in hover or later flight states.

--- a/robots/dracomancer/docs/dracomancer_system.md
+++ b/robots/dracomancer/docs/dracomancer_system.md
@@ -41,7 +41,7 @@ flowchart TB
 | `control_position.py` | 操縦桿とIMUから DRAGON の速度指令を生成 | joystick, IMU, flight_state | `/dragon/uav/nav` |
 | `control_orientation.py` | 操縦桿から姿勢指令を生成 | joystick, flight_state | `/dragon/final_target_baselink_rpy` |
 | `control_joint_angle.py` | 腕関節から DRAGON の形状指令を生成（安全スケールを購読して抑制） | joint_states, safety_scale, flight_state | `/dragon/joints_ctrl`, `/dracomancer/shape_control_error` |
-| `volume_radius_monitor.py` | fc 内接半径の中継・しきい値 pub/sub・安全スケール算出（bringup.launch で常時起動） | fc inradius, threshold cmd | `/dracomancer/force_volume_radius`, `/dracomancer/torque_volume_radius`, `*_threshold`, `/dracomancer/dragon_shape_safety`, `/dracomancer/dragon_shape_safety_scale` |
+| `volume_radius_monitor.py` | しきい値 pub/sub・安全スケール算出（bringup.launch で常時起動。fc 内接半径は再 pub しない） | fc inradius, threshold cmd | `*_volume_radius_threshold`, `/dracomancer/dragon_shape_safety_scale` |
 | `control_haptic_feedback.py` | 抑制された形状入力から力覚提示を生成 | joint_states, shape_control_error, mode | `/dracomancer/haptic_torque`, `/servo/target_current` |
 | `publish_fake_joint_states.py` | 実機なしで Dracomancer 関節状態を生成 | `/dracomancer/joint_cmd` | `/dracomancer/joint_states` |
 
@@ -89,8 +89,7 @@ flowchart TB
 | `/dracomancer/joint_states` | `sensor_msgs/JointState` | Dracomancer の腕関節角 |
 | `/dragon/uav/nav` | `aerial_robot_msgs/FlightNav` | DRAGON の速度指令 |
 | `/dragon/joints_ctrl` | `sensor_msgs/JointState` | DRAGON の形状指令 |
-| `/dracomancer/dragon_shape_safety` | `std_msgs/Float64MultiArray` | `[force_inradius, torque_inradius, safety_scale]`（`volume_radius_monitor.py` が pub） |
-| `/dracomancer/dragon_shape_safety_scale` | `std_msgs/Float64` | 安全スケール（`control_joint_angle.py` が購読） |
+| `/dracomancer/dragon_shape_safety_scale` | `std_msgs/Float64` | 安全スケール（`volume_radius_monitor.py` が pub、`control_joint_angle.py` と web UI が購読） |
 | `/dracomancer/shape_control_error` | `std_msgs/Float64MultiArray` | 力覚提示用の形状抑制量 `q_des - q_tar` |
 | `/dracomancer/haptic_torque` | `sensor_msgs/JointState` | 安全スケーリングで抑制された入力差から計算した Dracomancer 7関節の提示トルク |
 
@@ -275,12 +274,10 @@ rad = (tick - 2048) * 2*pi / 4096 + offset
 | `/dragon/debug/fc_f_min` | 力の実現可能内接半径 |
 | `/dragon/debug/fc_t_min` | トルクの実現可能内接半径 |
 
-Dracomancer 側へは以下の topic でも同じ半径を出します（`volume_radius_monitor.py` が publish）。
+内接半径そのものは **DRAGON 側の `/dragon/debug/fc_*_min` を直接購読**してください。Dracomancer では再 publish しません（重複回避）。`volume_radius_monitor.py` が Dracomancer 側へ出すのは、しきい値と安全スケールだけです。
 
 | トピック | 型 | 意味 |
 | --- | --- | --- |
-| `/dracomancer/force_volume_radius` | `std_msgs/Float64` | 力の実現可能内接半径 |
-| `/dracomancer/torque_volume_radius` | `std_msgs/Float64` | トルクの実現可能内接半径 |
 | `/dracomancer/force_volume_radius_threshold` | `std_msgs/Float64MultiArray` | 力のしきい値 `[hard_min, min]`（常時 publish） |
 | `/dracomancer/torque_volume_radius_threshold` | `std_msgs/Float64MultiArray` | トルクのしきい値 `[hard_min, min]`（常時 publish） |
 | `/dracomancer/force_volume_radius_threshold_cmd` | `std_msgs/Float64MultiArray` | 力のしきい値 `[hard_min, min]` を実行時に設定（subscribe） |
@@ -358,12 +355,12 @@ scale = max(min_safety_scale, min(1.0, force_margin, torque_margin))
 モニタリング:
 
 ```bash
-rostopic echo /dracomancer/dragon_shape_safety
-rostopic echo /dracomancer/force_volume_radius
-rostopic echo /dracomancer/torque_volume_radius
+rostopic echo /dracomancer/dragon_shape_safety_scale   # 安全スケール
+rostopic echo /dragon/debug/fc_f_min                    # 力の内接半径（DRAGON 由来）
+rostopic echo /dragon/debug/fc_t_min                    # トルクの内接半径（DRAGON 由来）
 ```
 
-ログには `state=safe|warning|danger|missing_inradius|disabled`、`force_volume_radius`、`torque_volume_radius`、`safety_scale` を出力します。
+ログには `state=safe|warning|danger|missing_inradius|disabled`、`force_volume_radius`、`torque_volume_radius`、`safety_scale` を出力します（ログ内の半径値は参照用で、トピックとしては再 publish しません）。
 
 ## 力覚提示
 
@@ -538,7 +535,7 @@ roslaunch dracomancer teleoperation.launch nav_target:=baselink direction_mode:=
 ```bash
 rostopic echo /dragon/uav/nav
 rostopic echo /dragon/joints_ctrl
-rostopic echo /dracomancer/dragon_shape_safety
+rostopic echo /dracomancer/dragon_shape_safety_scale
 ```
 
 DRAGON がすぐ落下する場合の切り分け:

--- a/robots/dracomancer/docs/dracomancer_system.md
+++ b/robots/dracomancer/docs/dracomancer_system.md
@@ -40,8 +40,9 @@ flowchart TB
 | `convert_servo_to_joint_states.py` | サーボtickをラジアンの関節状態へ変換 | `/dracomancer/servo/states` | `/dracomancer/joint_states` |
 | `control_position.py` | 操縦桿とIMUから DRAGON の速度指令を生成 | joystick, IMU, flight_state | `/dragon/uav/nav` |
 | `control_orientation.py` | 操縦桿から姿勢指令を生成 | joystick, flight_state | `/dragon/final_target_baselink_rpy` |
-| `control_joint_angle.py` | 腕関節から DRAGON の形状指令を生成（安全スケールを購読して抑制） | joint_states, safety_scale, flight_state | `/dragon/joints_ctrl`, `/dracomancer/shape_control_error` |
-| `volume_radius_monitor.py` | しきい値 pub/sub・安全スケール算出（bringup.launch で常時起動。fc 内接半径は再 pub しない） | fc inradius, threshold cmd | `*_volume_radius_threshold`, `/dracomancer/dragon_shape_safety_scale` |
+| `control_joint_angle.py` | 腕関節から DRAGON の形状指令を生成（候補姿勢のフィージビリティで変形可否を判定） | joint_states, shape_feasibility, threshold, flight_state | `/dragon/joints_ctrl`, `/dracomancer/shape_control_error` |
+| `shape_feasibility_node`（C++） | 候補リンク角の force/torque volume 半径を DRAGON モデルで予測するサービス | candidate joints | `~check_shape`（fc_f_min, fc_t_min） |
+| `volume_radius_monitor.py` | しきい値 pub/sub・ライブ安全スケール算出（bringup.launch で常時起動。fc 内接半径は再 pub しない） | fc inradius, threshold cmd | `*_volume_radius_threshold`, `/dracomancer/dragon_shape_safety_scale` |
 | `control_haptic_feedback.py` | 抑制された形状入力から力覚提示を生成 | joint_states, shape_control_error, mode | `/dracomancer/haptic_torque`, `/servo/target_current` |
 | `publish_fake_joint_states.py` | 実機なしで Dracomancer 関節状態を生成 | `/dracomancer/joint_cmd` | `/dracomancer/joint_states` |
 
@@ -89,7 +90,7 @@ flowchart TB
 | `/dracomancer/joint_states` | `sensor_msgs/JointState` | Dracomancer の腕関節角 |
 | `/dragon/uav/nav` | `aerial_robot_msgs/FlightNav` | DRAGON の速度指令 |
 | `/dragon/joints_ctrl` | `sensor_msgs/JointState` | DRAGON の形状指令 |
-| `/dracomancer/dragon_shape_safety_scale` | `std_msgs/Float64` | 安全スケール（`volume_radius_monitor.py` が pub、`control_joint_angle.py` と web UI が購読） |
+| `/dracomancer/dragon_shape_safety_scale` | `std_msgs/Float64` | ライブ安全スケール（`volume_radius_monitor.py` が pub、web UI が購読。情報提供用） |
 | `/dracomancer/shape_control_error` | `std_msgs/Float64MultiArray` | 力覚提示用の形状抑制量 `q_des - q_tar` |
 | `/dracomancer/haptic_torque` | `sensor_msgs/JointState` | 安全スケーリングで抑制された入力差から計算した Dracomancer 7関節の提示トルク |
 
@@ -260,21 +261,34 @@ rad = (tick - 2048) * 2*pi / 4096 + offset
 
 ## 形状安全機構
 
-形状安全は **2ノード構成**です。
+形状安全は **予測フィージビリティ・ゲート**（precision モードの主機構）と **ライブ監視**（情報提供）の2層です。
 
-- `volume_radius_monitor.py`（**bringup.launch** で常時起動）: DRAGON 側の実現可能制御内接半径（feasible control inradius）を参照し、半径・しきい値・安全スケールを算出して publish。しきい値の実行時更新も受け付ける。
-- `control_joint_angle.py`（teleoperation.launch）: 安全スケールを購読し、明らかに飛行不可能な形状へ強く押し込まないよう関節指令をスケーリングする。
+### 1. 予測フィージビリティ・ゲート（precision モード）
 
-> モニタを bringup 側に置くことで、テレオペレーション（位置・姿勢・関節角操作）がホバリング以外で無効化されていても、安全半径系の pub/sub は動き続けます。
+腕関節を DRAGON 形状にマッピングした**候補姿勢**を、実際に送る前に評価します。
 
-入力となる安全指標（`volume_radius_monitor.py` が購読）:
+```mermaid
+flowchart TD
+    A["腕関節 → 候補 DRAGON 形状"] --> B["shape_feasibility サービスで予測<br/>fc_f_min, fc_t_min（DRAGONモデル）"]
+    B --> C{"fc_f_min >= force_thr<br/>かつ fc_t_min >= torque_thr ?"}
+    C -->|yes| D["変形可：候補を採用し記憶<br/>last_feasible_target = 候補"]
+    C -->|no / サービス失敗| E["変形しない：直前の可行姿勢を保持"]
+    D --> F["max_step で1周期の変化量を制限して送信"]
+    E --> F
+```
 
-| トピック | 意味 |
-| --- | --- |
-| `/dragon/debug/fc_f_min` | 力の実現可能内接半径 |
-| `/dragon/debug/fc_t_min` | トルクの実現可能内接半径 |
+- **判定基準**：force・torque **両方**の予測半径が下限しきい値以上なら変形可。
+- **NG時**：直前に可行だった形状（`last_feasible_target`）を保持し、そこから動かさない。
+- 予測はサービス `shape_feasibility/check_shape` が `dragon/full_vectoring_robot_model` プラグインで計算します。**ジンバルの公称計画を含む近似予測**で、DRAGON が実際に達成する半径に近い値です（オンラインの角度制限・ロックは無視）。
+- 最適化が毎回走るため、評価は `feasibility_rate`（既定 20Hz）にスロットルされます。
 
-内接半径そのものは **DRAGON 側の `/dragon/debug/fc_*_min` を直接購読**してください。Dracomancer では再 publish しません（重複回避）。`volume_radius_monitor.py` が Dracomancer 側へ出すのは、しきい値と安全スケールだけです。
+> `shape_feasibility_node` は DRAGON の namespace（`ns=dragon`）で起動し、モデルが `/dragon/robot_description` と機体パラメータを読みます。**DRAGON が起動している必要があります。**
+
+### 2. ライブ監視（`volume_radius_monitor.py`、bringup.launch）
+
+実機の**現在状態**の fc 内接半径からライブの安全スケールを算出して publish します（web UI 表示・記録用、ゲートとは独立）。bringup 側にあるため、テレオペレーションがホバリング以外で無効化されていても動き続けます。fc 内接半径そのものは **DRAGON の `/dragon/debug/fc_*_min` を直接購読**してください（Dracomancer では再 publish しません）。
+
+### しきい値トピック（`volume_radius_monitor.py` が所有・pub/sub、ゲートも購読）
 
 | トピック | 型 | 意味 |
 | --- | --- | --- |
@@ -283,40 +297,9 @@ rad = (tick - 2048) * 2*pi / 4096 + offset
 | `/dracomancer/force_volume_radius_threshold_cmd` | `std_msgs/Float64MultiArray` | 力のしきい値 `[hard_min, min]` を実行時に設定（subscribe） |
 | `/dracomancer/torque_volume_radius_threshold_cmd` | `std_msgs/Float64MultiArray` | トルクのしきい値 `[hard_min, min]` を実行時に設定（subscribe） |
 
-しきい値の更新は `hard_min <= min` の場合のみ反映され、要素数が 2 未満や逆転している指令は警告して無視します。
+`control_joint_angle.py` はこれらの `[hard_min, min]` の **`hard_min`（先頭）をゲートの下限しきい値**として使います。トピック未受信時は `force_radius_threshold`/`torque_radius_threshold` パラメータ（既定 `0.1`/`0.01`）を使います。しきい値更新は `hard_min <= min` の場合のみ反映します。
 
-安全スケール:
-
-```mermaid
-flowchart TD
-    START["関節指令を生成"] --> EN{"enable_shape_safety?"}
-    EN -->|false| FULL["scale = 1.0"]
-    EN -->|true| RDY{"内接半径が最新?"}
-    RDY -->|no| MISS["scale = missing_inradius_scale"]
-    RDY -->|yes| HARD{"force または torque が hard_min 以下?"}
-    HARD -->|yes| MIN["scale = min_safety_scale"]
-    HARD -->|no| MARGIN["force / torque margin の小さい方"]
-```
-
-計算:
-
-```text
-force_margin  = (force  - force_hard_min)  / (force_min  - force_hard_min)
-torque_margin = (torque - torque_hard_min) / (torque_min - torque_hard_min)
-scale = max(min_safety_scale, min(1.0, force_margin, torque_margin))
-```
-
-`volume_radius_monitor.py` は算出した scale を `/dracomancer/dragon_shape_safety_scale`（`std_msgs/Float64`）として publish し、`control_joint_angle.py` がこれを購読します。
-
-スケール適用（`control_joint_angle.py`）:
-
-- 受信した scale が古い（`safety_scale_timeout` 超過）または未受信のときは `missing_safety_scale`（既定 `1.0`＝抑制なし）を使う
-- `scale <= 0`: `safe_pose` へ戻す
-- `0 < scale < 1`: `safe_pose` とマッピング結果を線形補間
-- `scale >= 1`: マッピング結果をそのまま使う
-- 最後に `max_step` で1周期あたりの関節変化量を制限する
-
-送信ゲート（ホバリング以外では位置・姿勢・関節角操作を無効化）:
+### 送信ゲート（ホバリング以外では位置・姿勢・関節角操作を無効化）
 
 | 条件 | 既定 | 挙動 |
 | --- | --- | --- |
@@ -325,32 +308,35 @@ scale = max(min_safety_scale, min(1.0, force_margin, torque_margin))
 
 > `control_position.py`（`wide && hovering && !landing`）と `control_orientation.py`（`publish_only_when_hovering` 既定 true）も同様にホバリング時のみ出力します。
 
-主なパラメータ:
-
-`volume_radius_monitor.py`（bringup.launch）:
-
-| パラメータ | 既定 | 説明 |
-| --- | --- | --- |
-| `enable_shape_safety` | `true` | 安全スケーリングの有効化（false で scale=1.0 を pub） |
-| `force_inradius_min` | `0.2` | 力余裕の上端 |
-| `force_inradius_hard_min` | `0.1` | 力の危険しきい値 |
-| `torque_inradius_min` | `0.02` | トルク余裕の上端 |
-| `torque_inradius_hard_min` | `0.01` | トルクの危険しきい値 |
-| `missing_inradius_scale` | `1.0` | 半径未受信時のスケール |
-| `min_safety_scale` | `0.0` | スケール下限 |
-| `inradius_timeout` | `0.5` | 内接半径の有効期限 [s] |
-| `safety_log_period` | `1.0` | 危険状態・半径・スケールをログ出力する周期 |
+### 主なパラメータ
 
 `control_joint_angle.py`（teleoperation.launch）:
 
 | パラメータ | 既定 | 説明 |
 | --- | --- | --- |
-| `safety_scale_topic` | `/dracomancer/dragon_shape_safety_scale` | 購読する安全スケール |
-| `safety_scale_timeout` | `0.5` | スケールの有効期限 [s] |
-| `missing_safety_scale` | `1.0` | スケール未受信時の代替値 |
+| `enable_feasibility_gate` | `true` | 予測ゲートの有効化（false で候補をそのまま採用） |
+| `feasibility_service` | `/dragon/shape_feasibility/check_shape` | 予測サービス名 |
+| `feasibility_rate` | `20.0` | 候補評価のスロットル周波数 [Hz] |
+| `force_radius_threshold` | `0.1` | 力の下限しきい値（topic 未受信時のフォールバック） |
+| `torque_radius_threshold` | `0.01` | トルクの下限しきい値（同上） |
 | `max_step` | `0.04` | 1周期あたりの最大変化量 |
 | `startup_pose` | `[0, pi/2, 0, pi/2, 0, pi/2]` | 立ち上げ時の通常姿勢 |
 | `wide_hold_pose` | `startup_pose` | 広域移動中に保持する形状 |
+
+`shape_feasibility_node`（teleoperation.launch、`ns=dragon`）:
+
+| パラメータ | 既定 | 説明 |
+| --- | --- | --- |
+| `robot_model_plugin_name` | `dragon/full_vectoring_robot_model` | 予測に使う DRAGON モデルプラグイン |
+
+`volume_radius_monitor.py`（bringup.launch、ライブ監視）:
+
+| パラメータ | 既定 | 説明 |
+| --- | --- | --- |
+| `enable_shape_safety` | `true` | ライブスケール算出の有効化 |
+| `force_inradius_min` / `force_inradius_hard_min` | `0.2` / `0.1` | 力のしきい値（帯） |
+| `torque_inradius_min` / `torque_inradius_hard_min` | `0.02` / `0.01` | トルクのしきい値（帯） |
+| `inradius_timeout` | `0.5` | 内接半径の有効期限 [s] |
 
 モニタリング:
 

--- a/robots/dracomancer/launch/teleoperation.launch
+++ b/robots/dracomancer/launch/teleoperation.launch
@@ -15,10 +15,14 @@
   <arg name="servo_topic" default="/dracomancer/servo/states"/>
   <arg name="enable_servo_to_joint_states" default="true"/>
   <arg name="servo_to_joint_states_rate" default="40.0"/>
-  <!-- Shape-safety scale is produced by volume_radius_monitor in bringup.launch. -->
-  <arg name="safety_scale_topic" default="/$(arg device_ns)/dragon_shape_safety_scale"/>
-  <arg name="safety_scale_timeout" default="0.5"/>
-  <arg name="missing_safety_scale" default="1.0"/>
+  <!-- Predictive shape-feasibility gate (precision mode).
+       shape_feasibility_node runs in the controlled robot's namespace so its
+       robot model can read <robot_ns>/robot_description. -->
+  <arg name="enable_feasibility_gate" default="true"/>
+  <arg name="feasibility_service" default="/$(arg robot_ns)/shape_feasibility/check_shape"/>
+  <arg name="robot_model_plugin_name" default="dragon/full_vectoring_robot_model"/>
+  <arg name="force_radius_threshold" default="0.1"/>
+  <arg name="torque_radius_threshold" default="0.01"/>
   <arg name="max_step" default="0.04"/>
   <arg name="joint_limit" default="1.57079632679"/>
   <arg name="capture_neutral_on_first_msg" default="false"/>
@@ -173,8 +177,21 @@
     <param name="capture_neutral_on_first_msg" value="$(arg capture_neutral_on_first_msg)"/>
     <param name="publish_only_when_hovering" value="$(arg publish_joints_only_when_hovering)"/>
     <param name="publish_before_device_ready" value="$(arg publish_joints_before_device_ready)"/>
-    <param name="safety_scale_topic" value="$(arg safety_scale_topic)"/>
-    <param name="safety_scale_timeout" value="$(arg safety_scale_timeout)"/>
-    <param name="missing_safety_scale" value="$(arg missing_safety_scale)"/>
+    <param name="enable_feasibility_gate" value="$(arg enable_feasibility_gate)"/>
+    <param name="feasibility_service" value="$(arg feasibility_service)"/>
+    <param name="force_radius_threshold" value="$(arg force_radius_threshold)"/>
+    <param name="torque_radius_threshold" value="$(arg torque_radius_threshold)"/>
+  </node>
+
+  <!-- Predictive shape-feasibility server. Runs in the controlled robot's
+       namespace so the robot model reads <robot_ns>/robot_description and rotor
+       rosparams. Requires the controlled robot (DRAGON) to be running. -->
+  <node pkg="dracomancer"
+        type="shape_feasibility_node"
+        name="shape_feasibility"
+        ns="$(arg robot_ns)"
+        output="screen"
+        if="$(arg enable_feasibility_gate)">
+    <param name="robot_model_plugin_name" value="$(arg robot_model_plugin_name)"/>
   </node>
 </launch>

--- a/robots/dracomancer/package.xml
+++ b/robots/dracomancer/package.xml
@@ -14,25 +14,31 @@
   <build_depend>aerial_robot_model</build_depend>
   <build_depend>aerial_robot_msgs</build_depend>
   <build_depend>pluginlib</build_depend>
+  <build_depend>message_generation</build_depend>
   <build_depend>message_runtime</build_depend>
   <build_depend>diagnostic_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
-  <!-- <build_depend>roscpp</build_depend>
-  <build_depend>rospy</build_depend> -->
- 
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <!-- <build_depend>rospy</build_depend> -->
+
   <run_depend>aerial_robot_control</run_depend>
   <run_depend>aerial_robot_model</run_depend>
   <run_depend>aerial_robot_msgs</run_depend>
   <run_depend>aerial_robot_estimation</run_depend>
   <run_depend>aerial_robot_simulation</run_depend>
   <run_depend>aerial_robot_base</run_depend>
+  <!-- dragon provides the robot model plugin loaded at runtime by
+       shape_feasibility_node (pluginlib). Required only for teleoperating DRAGON. -->
+  <run_depend>dragon</run_depend>
   <run_depend>spinal</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>diagnostic_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>sensor_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
 
   <export>

--- a/robots/dracomancer/scripts/control_joint_angle.py
+++ b/robots/dracomancer/scripts/control_joint_angle.py
@@ -3,8 +3,9 @@
 
 import rospy
 import numpy as np
-from std_msgs.msg import Float64, Float64MultiArray, UInt8, String
+from std_msgs.msg import Float64MultiArray, UInt8, String
 from sensor_msgs.msg import JointState
+from dracomancer.srv import ShapeFeasibility, ShapeFeasibilityRequest
 
 class ControlJoints:
     def __init__(self):
@@ -52,30 +53,53 @@ class ControlJoints:
         self.publish_before_device_ready = rospy.get_param("~publish_before_device_ready", False)
 
         self.shape_error_topic = rospy.get_param("~shape_error_topic", self.device_ns + "/shape_control_error")
-        # Shape-safety scale is computed by volume_radius_monitor (bringup.launch) and
-        # consumed here to blend joint commands toward safe_pose. When the scale is
-        # stale/absent, missing_safety_scale (default 1.0 = no limiting) is used.
-        self.safety_scale_topic = rospy.get_param(
-            "~safety_scale_topic", self.device_ns + "/dragon_shape_safety_scale")
-        self.safety_scale_timeout = rospy.get_param("~safety_scale_timeout", 0.5)
-        self.missing_safety_scale = rospy.get_param("~missing_safety_scale", 1.0)
+
+        # Predictive shape-feasibility gate (precision mode):
+        #   candidate shape -> shape_feasibility service -> fc_f_min / fc_t_min.
+        #   Deform only when BOTH radii are at or above their lower thresholds;
+        #   otherwise hold the last feasible shape.
+        self.enable_feasibility_gate = rospy.get_param("~enable_feasibility_gate", True)
+        self.feasibility_service_name = rospy.get_param(
+            "~feasibility_service", "/" + self.robot_name + "/shape_feasibility/check_shape")
+        self.feasibility_service_timeout = rospy.get_param("~feasibility_service_timeout", 2.0)
+        # The model plugin runs a gimbal-planning optimization per call, so throttle
+        # how often the candidate is re-evaluated (Hz). Between checks the last
+        # feasible shape is held.
+        self.feasibility_rate = rospy.get_param("~feasibility_rate", 20.0)
+        # Lower thresholds (fallback params; overridden by the threshold topics below).
+        self.force_radius_threshold = rospy.get_param("~force_radius_threshold", 0.1)
+        self.torque_radius_threshold = rospy.get_param("~torque_radius_threshold", 0.01)
+        # Threshold topics carry [hard_min, min]; hard_min ([0]) is used as the gate bound.
+        self.force_threshold_topic = rospy.get_param(
+            "~force_volume_radius_threshold_topic", self.device_ns + "/force_volume_radius_threshold")
+        self.torque_threshold_topic = rospy.get_param(
+            "~torque_volume_radius_threshold_topic", self.device_ns + "/torque_volume_radius_threshold")
+        self.gate_log_period = rospy.get_param("~gate_log_period", 1.0)
 
         self.latest_device_joints = {}
         self.neutral_device_joints = {}
         self.current_target = list(self.safe_pose)
-        self.safety_scale_value = None
-        self.last_safety_scale_stamp = rospy.Time(0)
+        self.last_feasible_target = list(self.safe_pose)
         self.robot_hovering = False
+        self.last_gate_log_stamp = rospy.Time(0)
+        self.last_gate_feasible = None
+        self.last_feasibility_eval_stamp = rospy.Time(0)
 
         # Publisher
         self.joints_ctrl_pub = rospy.Publisher(self.command_topic, JointState, queue_size=10)
         self.shape_error_pub = rospy.Publisher(self.shape_error_topic, Float64MultiArray, queue_size=1)
 
+        # Service client (persistent for rate; reconnected on failure)
+        self.feasibility_srv = None
+        if self.enable_feasibility_gate:
+            self.connect_feasibility_service()
+
         # Subscriber
         self.device_joint_sub = rospy.Subscriber(self.device_joint_topic, JointState, self.device_joint_cb, queue_size=1)
-        self.safety_scale_sub = rospy.Subscriber(self.safety_scale_topic, Float64, self.safety_scale_cb, queue_size=1)
         self.robot_flight_state_sub = rospy.Subscriber('/' + self.robot_name + '/flight_state', UInt8, self.robot_flight_state_cb, queue_size=1)
         self.mode_sub = rospy.Subscriber(self.mode_topic, String, self.mode_cb, queue_size=1)
+        self.force_threshold_sub = rospy.Subscriber(self.force_threshold_topic, Float64MultiArray, self.force_threshold_cb, queue_size=1)
+        self.torque_threshold_sub = rospy.Subscriber(self.torque_threshold_topic, Float64MultiArray, self.torque_threshold_cb, queue_size=1)
 
         rospy.loginfo("teleop_mode: %s, mode_topic: %s", self.teleop_mode, self.mode_topic)
         rospy.loginfo("device_joint_topic: %s", self.device_joint_topic)
@@ -88,10 +112,22 @@ class ControlJoints:
                           name, scale, sign, offset)
                                 for name, scale, sign, offset in zip(
                                     self.joint_names, self.scales, self.signs, self.offsets)))
-        rospy.loginfo("safety scale topic: %s (timeout=%.2f, missing=%.3f)",
-                      self.safety_scale_topic, self.safety_scale_timeout, self.missing_safety_scale)
+        rospy.loginfo("feasibility gate: enable=%s, service=%s, thresholds force/torque=%.4f/%.4f",
+                      self.enable_feasibility_gate, self.feasibility_service_name,
+                      self.force_radius_threshold, self.torque_radius_threshold)
         rospy.loginfo("joint command gating: only_when_hovering=%s, before_device_ready=%s",
                       self.publish_only_when_hovering, self.publish_before_device_ready)
+
+    def connect_feasibility_service(self):
+        try:
+            rospy.wait_for_service(self.feasibility_service_name, timeout=self.feasibility_service_timeout)
+            self.feasibility_srv = rospy.ServiceProxy(self.feasibility_service_name, ShapeFeasibility, persistent=True)
+            rospy.loginfo("connected to shape feasibility service: %s", self.feasibility_service_name)
+            return True
+        except rospy.ROSException:
+            rospy.logwarn_throttle(5.0, "shape feasibility service '%s' not available", self.feasibility_service_name)
+            self.feasibility_srv = None
+            return False
 
     def mode_cb(self, msg):
         mode = str(msg.data).strip().lower()
@@ -116,31 +152,26 @@ class ControlJoints:
                 }
                 rospy.loginfo("Captured dracomancer neutral joints for DRAGON mapping")
 
-    def safety_scale_cb(self, msg):
-        self.safety_scale_value = float(msg.data)
-        self.last_safety_scale_stamp = rospy.Time.now()
-
     def robot_flight_state_cb(self, msg):
         self.robot_hovering = int(msg.data) >= 4
 
-    def safety_scale(self):
-        # Use the latest scale from volume_radius_monitor; fall back to
-        # missing_safety_scale when it is absent or stale.
-        if self.safety_scale_value is None:
-            return max(0.0, min(1.0, self.missing_safety_scale))
-        if (rospy.Time.now() - self.last_safety_scale_stamp).to_sec() > self.safety_scale_timeout:
-            return max(0.0, min(1.0, self.missing_safety_scale))
-        return max(0.0, min(1.0, self.safety_scale_value))
+    def force_threshold_cb(self, msg):
+        if len(msg.data) > 0:
+            self.force_radius_threshold = float(msg.data[0])
+
+    def torque_threshold_cb(self, msg):
+        if len(msg.data) > 0:
+            self.torque_radius_threshold = float(msg.data[0])
 
     def mapped_target(self):
         if not self.latest_device_joints:
-            return list(self.safe_pose)
+            return list(self.last_feasible_target)
 
         target = []
         for i, source_name in enumerate(self.source_joint_names):
             source = self.latest_device_joints.get(source_name)
             if source is None:
-                target.append(self.current_target[i])
+                target.append(self.last_feasible_target[i])
                 continue
 
             neutral = self.neutral_device_joints.get(source_name, 0.0)
@@ -149,16 +180,73 @@ class ControlJoints:
 
         return target
 
+    def evaluate_feasibility(self, candidate):
+        # Returns (feasible: bool, fc_f_min, fc_t_min). On service failure returns
+        # (None, ...) so the caller can hold the last feasible shape conservatively.
+        if self.feasibility_srv is None:
+            if not self.connect_feasibility_service():
+                return None, None, None
+        req = ShapeFeasibilityRequest()
+        req.name = list(self.joint_names)
+        req.position = list(candidate)
+        try:
+            res = self.feasibility_srv.call(req)
+        except (rospy.ServiceException, TypeError):
+            rospy.logwarn_throttle(5.0, "shape feasibility service call failed; reconnecting")
+            self.feasibility_srv = None
+            return None, None, None
+        if not res.valid:
+            return None, res.fc_f_min, res.fc_t_min
+        feasible = (res.fc_f_min >= self.force_radius_threshold and
+                    res.fc_t_min >= self.torque_radius_threshold)
+        return feasible, res.fc_f_min, res.fc_t_min
+
+    def log_gate(self, feasible, fc_f, fc_t):
+        if feasible != self.last_gate_feasible:
+            self.last_gate_feasible = feasible
+        now = rospy.Time.now()
+        if self.gate_log_period > 0.0 and (now - self.last_gate_log_stamp).to_sec() < self.gate_log_period:
+            return
+        self.last_gate_log_stamp = now
+        f = "n/a" if fc_f is None else "%.4f" % fc_f
+        t = "n/a" if fc_t is None else "%.4f" % fc_t
+        msg = ("shape feasibility: deform=%s fc_f_min=%s fc_t_min=%s "
+               "thresholds(force/torque)=%.4f/%.4f") % (
+            feasible, f, t, self.force_radius_threshold, self.torque_radius_threshold)
+        if feasible:
+            rospy.loginfo(msg)
+        else:
+            rospy.logwarn(msg)
+
+    def precision_target(self):
+        # Map the arm to a candidate DRAGON shape, then gate by predicted feasibility.
+        candidate = self.mapped_target()
+        if not self.enable_feasibility_gate:
+            self.last_feasible_target = candidate
+            return candidate
+
+        # Throttle the (expensive) feasibility evaluation; hold between checks.
+        now = rospy.Time.now()
+        if self.feasibility_rate > 0.0 and \
+                (now - self.last_feasibility_eval_stamp).to_sec() < 1.0 / self.feasibility_rate:
+            return list(self.last_feasible_target)
+        self.last_feasibility_eval_stamp = now
+
+        feasible, fc_f, fc_t = self.evaluate_feasibility(candidate)
+        if feasible:
+            self.last_feasible_target = candidate
+        # feasible False or None (service failure / invalid) -> hold last feasible.
+        self.log_gate(bool(feasible), fc_f, fc_t)
+        return list(self.last_feasible_target)
+
     def desired_target(self):
         if self.teleop_mode == "startup":
+            self.last_feasible_target = list(self.startup_pose)
             return list(self.startup_pose)
         if self.teleop_mode == "wide":
+            self.last_feasible_target = list(self.wide_hold_pose)
             return list(self.wide_hold_pose)
-        return self.mapped_target()
-
-    @staticmethod
-    def blend(a, b, ratio):
-        return [ai + ratio * (bi - ai) for ai, bi in zip(a, b)]
+        return self.precision_target()
 
     def rate_limit(self, target):
         limited = []
@@ -173,16 +261,9 @@ class ControlJoints:
         self.shape_error_pub.publish(msg)
 
     def make_joint_msg(self):
-        scale = self.safety_scale()
-        desired = self.desired_target()
-
-        if scale <= 0.0:
-            target = list(self.safe_pose)
-        elif scale < 1.0:
-            target = self.blend(self.safe_pose, desired, scale)
-        else:
-            target = desired
-
+        target = self.desired_target()
+        # desired (raw mapping) vs target (feasible-gated) error, for haptic feedback.
+        desired = self.mapped_target() if self.teleop_mode == "precision" else target
         self.publish_shape_error(desired, target)
         self.current_target = self.rate_limit(target)
 

--- a/robots/dracomancer/scripts/volume_radius_monitor.py
+++ b/robots/dracomancer/scripts/volume_radius_monitor.py
@@ -41,13 +41,9 @@ class VolumeRadiusMonitor:
         self.min_safety_scale = rospy.get_param("~min_safety_scale", 0.0)
         self.safety_log_period = rospy.get_param("~safety_log_period", 1.0)
 
-        # Output topics.
-        self.shape_safety_topic = rospy.get_param("~shape_safety_topic", self.device_ns + "/dragon_shape_safety")
+        # Output topics. Only dracomancer-computed quantities are published here;
+        # the raw inradius is NOT republished (consume /<robot>/debug/fc_*_min directly).
         self.safety_scale_topic = rospy.get_param("~safety_scale_topic", self.device_ns + "/dragon_shape_safety_scale")
-        self.force_volume_radius_topic = rospy.get_param(
-            "~force_volume_radius_topic", self.device_ns + "/force_volume_radius")
-        self.torque_volume_radius_topic = rospy.get_param(
-            "~torque_volume_radius_topic", self.device_ns + "/torque_volume_radius")
         self.force_volume_radius_threshold_topic = rospy.get_param(
             "~force_volume_radius_threshold_topic", self.device_ns + "/force_volume_radius_threshold")
         self.torque_volume_radius_threshold_topic = rospy.get_param(
@@ -64,10 +60,7 @@ class VolumeRadiusMonitor:
         self.last_safety_log_stamp = rospy.Time(0)
 
         # Publishers.
-        self.shape_safety_pub = rospy.Publisher(self.shape_safety_topic, Float64MultiArray, queue_size=1)
         self.safety_scale_pub = rospy.Publisher(self.safety_scale_topic, Float64, queue_size=1)
-        self.force_volume_radius_pub = rospy.Publisher(self.force_volume_radius_topic, Float64, queue_size=1)
-        self.torque_volume_radius_pub = rospy.Publisher(self.torque_volume_radius_topic, Float64, queue_size=1)
         self.force_volume_radius_threshold_pub = rospy.Publisher(
             self.force_volume_radius_threshold_topic, Float64MultiArray, queue_size=1)
         self.torque_volume_radius_threshold_pub = rospy.Publisher(
@@ -193,11 +186,7 @@ class VolumeRadiusMonitor:
         scale = float(self.safety_scale())
         state = self.safety_state(scale)
 
-        self.shape_safety_pub.publish(
-            Float64MultiArray(data=[force_radius, torque_radius, scale]))
         self.safety_scale_pub.publish(Float64(scale))
-        self.force_volume_radius_pub.publish(Float64(force_radius))
-        self.torque_volume_radius_pub.publish(Float64(torque_radius))
         self.force_volume_radius_threshold_pub.publish(
             Float64MultiArray(data=[float(self.force_inradius_hard_min), float(self.force_inradius_min)]))
         self.torque_volume_radius_threshold_pub.publish(

--- a/robots/dracomancer/src/shape_feasibility_node.cpp
+++ b/robots/dracomancer/src/shape_feasibility_node.cpp
@@ -1,0 +1,110 @@
+/*
+ * shape_feasibility_node
+ *
+ * Predicts the feasible-control force/torque volume inradius (fc_f_min /
+ * fc_t_min) of a *candidate* articulated-aerial-robot shape, before the shape
+ * command is actually sent. It loads the controlled robot's model (e.g.
+ * DRAGON) through pluginlib and evaluates getFeasibleControlF/TMin() for the
+ * requested link joint angles. Gimbal joints are filled by the model with its
+ * nominal (hovering) angles, so the result is an approximate prediction.
+ *
+ * Run this node in the controlled robot's namespace (e.g. ns="dragon") so the
+ * robot model reads <robot_ns>/robot_description and rotor rosparams.
+ */
+
+#include <ros/ros.h>
+#include <pluginlib/class_loader.h>
+#include <sensor_msgs/JointState.h>
+#include <aerial_robot_model/model/aerial_robot_model.h>
+#include <dracomancer/ShapeFeasibility.h>
+
+class ShapeFeasibilityServer
+{
+public:
+  ShapeFeasibilityServer(ros::NodeHandle nh, ros::NodeHandle nhp)
+    : nh_(nh), nhp_(nhp),
+      robot_model_loader_("aerial_robot_model", "aerial_robot_model::RobotModel")
+  {
+    // Plugin name: prefer the controlled robot's own param, allow private override.
+    std::string plugin_name;
+    if (!nhp_.getParam("robot_model_plugin_name", plugin_name) &&
+        !nh_.getParam("robot_model_plugin_name", plugin_name))
+      {
+        plugin_name = "dragon/full_vectoring_robot_model";
+        ROS_WARN("shape_feasibility: robot_model_plugin_name not set, using default '%s'",
+                 plugin_name.c_str());
+      }
+
+    try
+      {
+        robot_model_ = robot_model_loader_.createInstance(plugin_name);
+      }
+    catch (pluginlib::PluginlibException& ex)
+      {
+        ROS_ERROR("shape_feasibility: failed to load robot model plugin '%s': %s",
+                  plugin_name.c_str(), ex.what());
+        throw;
+      }
+
+    ROS_INFO("shape_feasibility: loaded robot model plugin '%s' (ns=%s)",
+             plugin_name.c_str(), nh_.getNamespace().c_str());
+
+    server_ = nhp_.advertiseService("check_shape", &ShapeFeasibilityServer::checkShape, this);
+  }
+
+private:
+  bool checkShape(dracomancer::ShapeFeasibility::Request& req,
+                  dracomancer::ShapeFeasibility::Response& res)
+  {
+    if (req.name.size() != req.position.size())
+      {
+        ROS_WARN_THROTTLE(1.0, "shape_feasibility: name/position size mismatch (%zu vs %zu)",
+                          req.name.size(), req.position.size());
+        res.valid = false;
+        return true;
+      }
+
+    sensor_msgs::JointState js;
+    js.name = req.name;
+    js.position = req.position;
+
+    try
+      {
+        // Unspecified joints (e.g. gimbals) default to 0 and are overwritten by
+        // the model's nominal-gimbal processing inside updateRobotModel().
+        robot_model_->updateRobotModel(js);
+        res.fc_f_min = robot_model_->getFeasibleControlFMin();
+        res.fc_t_min = robot_model_->getFeasibleControlTMin();
+        res.valid = true;
+      }
+    catch (std::exception& e)
+      {
+        ROS_WARN_THROTTLE(1.0, "shape_feasibility: model evaluation failed: %s", e.what());
+        res.valid = false;
+      }
+    return true;
+  }
+
+  ros::NodeHandle nh_, nhp_;
+  pluginlib::ClassLoader<aerial_robot_model::RobotModel> robot_model_loader_;
+  boost::shared_ptr<aerial_robot_model::RobotModel> robot_model_;
+  ros::ServiceServer server_;
+};
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "shape_feasibility_node");
+  ros::NodeHandle nh;
+  ros::NodeHandle nhp("~");
+  try
+    {
+      ShapeFeasibilityServer server(nh, nhp);
+      ros::spin();
+    }
+  catch (...)
+    {
+      ROS_ERROR("shape_feasibility_node: shutting down due to initialization error");
+      return 1;
+    }
+  return 0;
+}

--- a/robots/dracomancer/srv/ShapeFeasibility.srv
+++ b/robots/dracomancer/srv/ShapeFeasibility.srv
@@ -1,0 +1,10 @@
+# Evaluate the feasible-control force/torque volume radius of a candidate shape.
+# The candidate is given as the controlled robot's (e.g. DRAGON) link joint
+# angles. Gimbal joints are ignored here; the robot model fills them with its
+# nominal (hovering) angles, so this is an approximate prediction.
+string[] name        # candidate link joint names
+float64[] position   # candidate link joint angles [rad]
+---
+float64 fc_f_min     # predicted force volume inradius (nominal gimbal)
+float64 fc_t_min     # predicted torque volume inradius (nominal gimbal)
+bool valid           # false if the model could not be evaluated


### PR DESCRIPTION
PR #9 マージ後に追加した2コミットを develop へ反映します。

## ユーザー視点の変化

### 1. dracomancer から dragon の内接半径を再 publish しない（重複排除）
- `/dracomancer/force_volume_radius` ・ `/dracomancer/torque_volume_radius` ・ `/dracomancer/dragon_shape_safety` の publish を廃止。
- web コンソールは内接半径を `/dragon/debug/fc_*_min` から直接、safety scale を `/dracomancer/dragon_shape_safety_scale` から取得するよう変更。

### 2. precision モードに「候補姿勢の予測フィージビリティ・ゲート」を追加
- 腕関節を DRAGON 形状にマッピングした**候補姿勢**を、送る前に評価。
- 新ノード `shape_feasibility_node`（C++）が `dragon/full_vectoring_robot_model` で `fc_f_min`/`fc_t_min` を予測。
- force・torque **両方が下限しきい値以上**なら変形（採用）、未満／失敗なら**直前の可行姿勢で停止**。
- 旧来の連続スケール追従はこのゲートに置換。`shape_feasibility_node` は DRAGON 起動が前提。

## 確認したこと
- `catkin build dracomancer` 成功（新 C++ ノード・srv 生成含む）
- 全スクリプト `py_compile` OK、`roslaunch --files` で両 launch パース OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)