### PR TITLE
[Dracomancer] feat: teleoperation の既定を elbow_only 化し mapping_reference を整理

### DIFF
--- a/robots/dracomancer/AGENTS.md
+++ b/robots/dracomancer/AGENTS.md
@@ -75,7 +75,7 @@ Dracomancer は **DRAGON を遠隔操作する上肢外骨格（エクソスケ�
 ## control_joint_angle.py（形状制御）の設計
 
 - `startup`: `startup_pose`（既定 `[0, pi/2, 0, pi/2, 0, pi/2]`）を保持。
-- `teleoperation`: Dracomancer 腕関節を DRAGON 関節へマッピングし、**候補姿勢のフィージビリティで変形可否を判定**する（移動は `control_position.py` が同時に担当）。マッピングは `~mapping_mode` で切替（`joint_pairing`=既定: 3屈曲関節→3 yaw・pitch=0で平面保持 / `geometric`: 腕FK→面内yaw・面外pitch分解 / `elbow_only`: 肘屈曲角1自由度→DRAGON 中央 yaw 関節のみ（`elbow_target_joint`、既定 `joint2_yaw`。他は基準姿勢で保持））。詳細は [README.md](README.md) の関節マッピング節。
+- `teleoperation`: Dracomancer 腕関節を DRAGON 関節へマッピングし、**候補姿勢のフィージビリティで変形可否を判定**する（移動は `control_position.py` が同時に担当）。マッピングは `~mapping_mode` で切替（`elbow_only`=既定: 肘屈曲角1自由度→DRAGON 中央 yaw 関節のみ（`elbow_target_joint`、既定 `joint2_yaw`。他関節は直前値のまま変化させない） / `joint_pairing`: 3屈曲関節→3 yaw・pitch=0で平面保持 / `geometric`: 腕FK→面内yaw・面外pitch分解）。詳細は [README.md](README.md) の関節マッピング節。
 - **予測フィージビリティ・ゲート（主機構）**: 候補 DRAGON 形状を `shape_feasibility_node`（C++、`dragon/full_vectoring_robot_model` を pluginlib で読み込み、`ns=dragon` で起動）の `check_shape` サービスに渡し `fc_f_min`/`fc_t_min` を予測。force・torque 両方が下限しきい値以上なら変形（採用・記憶）、未満／サービス失敗なら直前可行姿勢で停止。下限しきい値は `*_volume_radius_threshold`（`[hard_min, min]` の `hard_min`）を購読、未受信時は `force_radius_threshold`/`torque_radius_threshold` パラメータ。
 - **ライブ監視（情報提供）**: `volume_radius_monitor.py`（bringup.launch）が実機現在状態の fc からライブスケールを `/dracomancer/dragon_shape_safety_scale` に publish（web UI 用、ゲートとは独立）。しきい値の所有・pub/sub もここ。
 - 位置・姿勢・関節角操作はいずれもホバリング（`flight_state>=4`）時のみ出力する（`publish_joints_only_when_hovering` 既定 true）。

--- a/robots/dracomancer/README.md
+++ b/robots/dracomancer/README.md
@@ -197,11 +197,11 @@ Dracomancer の腕関節を、DRAGON を1本の直列アームとみなして対
 
 | `mapping_mode` | 概要 |
 | --- | --- |
-| `joint_pairing`（**既定**） | 3つの屈曲関節を DRAGON の3つの yaw に1:1対応、pitch は 0 固定で平面保持 |
+| `joint_pairing` | 3つの屈曲関節を DRAGON の3つの yaw に1:1対応、pitch は 0 固定で平面保持 |
 | `geometric` | 腕の順運動学からリンク方向ベクトルを求め、面内(yaw)/面外(pitch)成分に分解 |
-| `elbow_only` | 肘屈曲角の1自由度を DRAGON の真ん中の yaw 関節だけに対応させる（他関節は基準姿勢で保持） |
+| `elbow_only`（**既定**） | 肘屈曲角の1自由度を DRAGON の真ん中の yaw 関節だけに対応させる（他関節は変化させず現状維持） |
 
-### joint_pairing（中期方式・既定）
+### joint_pairing（中期方式）
 
 屈曲関節（肩・肘・手首、すべて −X 軸）は同軸なので、これだけ動かすと腕は1平面内で曲がります。これを DRAGON の yaw に流し、pitch を定数に固定することで「**腕の面内曲げ＝DRAGON の面内形状**」を構造的に保証します。
 
@@ -221,8 +221,9 @@ target        = clamp(mapped, -joint_limit, joint_limit)
 ```
 
 - yaw の sign は蛇の曲がり向き。DRAGON が逆向きに曲がる場合は3つ揃えて反転（`geom_yaw_sign` も合わせる）。
-- `joint_pairing_reference=zero`（既定）は従来方式で、yaw の offset は 0。腕角度を DRAGON yaw へ直接入れるため、円形姿勢 `pi/2` から大きく離れた候補が出やすい。
-- `joint_pairing_reference=startup` は `startup_pose=[0, pi/2, 0, pi/2, 0, pi/2]` を offset に使い、円形姿勢からの相対変形にする。形状制御試験の推奨設定。
+- `mapping_reference=straight` は yaw の offset を 0 とする方式（DRAGON を真っ直ぐ伸ばす基準）。腕角度を DRAGON yaw へ直接入れるため、円形姿勢 `pi/2` から大きく離れた候補が出やすい。
+- `mapping_reference=circular`（既定）は `startup_pose=[0, pi/2, 0, pi/2, 0, pi/2]` を offset に使い、円形姿勢からの相対変形にする。テイクオフ円形からそのまま変形でき、形状制御試験の推奨設定。
+- ※ `mapping_reference` は全 `mapping_mode` 共通。旧名 `joint_pairing_reference` と旧値 `zero`/`startup` も後方互換で使用可（それぞれ `straight`/`circular` に対応）。
 - `joint_pairing_scale` は全関節の写像ゲインに掛かる一括係数。安全ゲートを残す試験では `0.2〜0.4` 程度から始める。
 - `capture_neutral_on_first_msg=true` にすると、最初に受け取った Dracomancer 関節角を `neutral` として記憶し、以後はそこからの差分を使う。
 - `joint_limit=pi/2` が既定。
@@ -232,8 +233,9 @@ target        = clamp(mapped, -joint_limit, joint_limit)
 
 ```bash
 roslaunch dracomancer teleoperation.launch \
+  mapping_mode:=joint_pairing \
   teleop_mode:=teleoperation \
-  joint_pairing_reference:=startup \
+  mapping_reference:=circular \
   capture_neutral_on_first_msg:=true \
   joint_pairing_scale:=0.3
 ```
@@ -252,25 +254,25 @@ FK -> 上腕/前腕/手の方向ベクトル
 - 主用途の屈曲ベース面内整形はクリーン。外転・捻りなど面外DOFは、リンク構造オフセットの影響で遠位関節に pitch/yaw 結合が出ることがある（既知の限界、研究比較用）。
 - パラメータ: `geom_chain`, `geom_plane_normal`, `geom_yaw_sign/scale`, `geom_pitch_sign/scale`。
 
-### elbow_only（1自由度・引数で選択）
+### elbow_only（1自由度・**既定**）
 
-肘の屈曲角（`elbow_source_joint`、既定 `elbow_flexion_extension_joint`）の中立からの差分**1つ**を、DRAGON の**真ん中の yaw 関節**（`elbow_target_joint`、既定は `dragon_joint_names` の中央 yaw = `joint2_yaw`）だけに対応させます。それ以外の関節は offset（基準姿勢）で保持されるため、`joint_pairing_reference=startup` なら DRAGON は円形を保ったまま中央の1関節だけが曲がります。肩・手首は使いません。マッピング比較実験での「最小自由度ベースライン」として使えます。
+肘の屈曲角（`elbow_source_joint`、既定 `elbow_flexion_extension_joint`）の中立からの差分**1つ**を、DRAGON の**真ん中の yaw 関節**（`elbow_target_joint`、既定は `dragon_joint_names` の中央 yaw = `joint2_yaw`）だけに対応させます。それ以外の関節は**直前に指令した値のまま保持され、一切変化しません**（DRAGON はテイクオフ時／直前の形状を維持し、中央の1関節だけが肘に追従して曲がる）。肩・手首は使いません。マッピング比較実験での「最小自由度ベースライン」として使えます。
 
 ```text
 delta = elbow - 中立elbow
 elbow_target_joint = offset + sign * scale * delta
-その他の関節        = offset（定数。pitch は 0、startup基準なら yaw は pi/2）
+その他の関節        = 直前の可行値（last_feasible_target、変化させない）
 ```
 
-- `joint_pairing` と同じ `signs` / `scales`（`joint_pairing_scale` 込み） / `offsets` / `joint_pairing_reference`(zero/startup) を再利用するので挙動が一貫。
+- 中央関節は `joint_pairing` と同じ `signs` / `scales`（`joint_pairing_scale` 込み） / `offsets` / `mapping_reference`(straight/circular) を再利用するので挙動が一貫。
+- 他の関節は offset を使わず直前値を保持するため、`mapping_reference` の straight/circular に関係なく動かない。
 - 対応先を変えたい場合は `elbow_target_joint` に DRAGON 関節名（例 `joint1_yaw`）を指定。
-- パラメータ: `elbow_source_joint`, `elbow_target_joint`（＋共有の `signs`/`scales`/`offsets`/`joint_pairing_reference`）。
+- パラメータ: `elbow_source_joint`, `elbow_target_joint`（＋共有の `signs`/`scales`/`offsets`/`mapping_reference`）。
 
 ```bash
 roslaunch dracomancer teleoperation.launch \
   teleop_mode:=teleoperation \
-  mapping_mode:=elbow_only \
-  joint_pairing_reference:=startup \
+  mapping_reference:=circular \
   capture_neutral_on_first_msg:=true \
   joint_pairing_scale:=0.3
 ```
@@ -363,8 +365,8 @@ flowchart TD
 
 | パラメータ | 既定 | 説明 |
 | --- | --- | --- |
-| `mapping_mode` | `joint_pairing` | 腕→DRAGON形状の写像方式 |
-| `joint_pairing_reference` | `zero` | `joint_pairing` の offset 基準。`startup` で円形姿勢基準 |
+| `mapping_mode` | `elbow_only` | 腕→DRAGON形状の写像方式 |
+| `mapping_reference` | `circular` | 写像の offset 基準（全モード共通）。`straight`=0rad基準 / `circular`=円形姿勢基準。旧名 `joint_pairing_reference`、旧値 `zero`/`startup` も可 |
 | `joint_pairing_scale` | `1.0` | `joint_pairing` の一括写像ゲイン |
 | `capture_neutral_on_first_msg` | `false` | 最初の Dracomancer 関節角を中立姿勢として記憶 |
 | `enable_feasibility_gate` | `true` | 予測ゲートの有効化（false で候補をそのまま採用） |

--- a/robots/dracomancer/launch/teleoperation.launch
+++ b/robots/dracomancer/launch/teleoperation.launch
@@ -35,14 +35,17 @@
   <arg name="max_step" default="0.04"/>
   <arg name="joint_limit" default="1.57079632679"/>
   <!-- Arm->DRAGON mapping strategy (teleoperation mode):
-         joint_pairing : flexion joints -> DRAGON yaw, pitch held at 0 (planar). Default.
+         joint_pairing : flexion joints -> DRAGON yaw, pitch held at 0 (planar).
          geometric     : arm FK -> link directions -> yaw/pitch decomposition.
-         elbow_only    : elbow flexion angle -> DRAGON's middle yaw joint only. -->
-  <arg name="mapping_mode" default="joint_pairing"/>
-  <!-- joint_pairing_reference (also used by elbow_only):
-         zero    : existing direct mapping around 0 rad.
-         startup : relative deformation around startup_pose (circular DRAGON shape). -->
-  <arg name="joint_pairing_reference" default="zero"/>
+         elbow_only    : elbow flexion angle -> DRAGON's middle yaw joint only;
+                         every other joint is held unchanged. Default. -->
+  <arg name="mapping_mode" default="elbow_only"/>
+  <!-- mapping_reference: base pose the arm->DRAGON mapping deforms around
+       (shared by every mapping_mode).
+         straight : map around 0 rad (DRAGON straightens out).
+         circular : relative deformation around startup_pose (circular DRAGON shape). Default. -->
+  <arg name="joint_pairing_reference" default="circular"/>  <!-- deprecated alias of mapping_reference -->
+  <arg name="mapping_reference" default="$(arg joint_pairing_reference)"/>
   <arg name="joint_pairing_scale" default="1.0"/>
   <!-- elbow_only: source (Dracomancer) joint and target DRAGON joint.
        elbow_target_joint empty -> middle yaw of dragon_joint_names. -->
@@ -197,7 +200,7 @@
     <param name="teleop_mode" value="$(arg teleop_mode)"/>
     <param name="mode_topic" value="$(arg mode_topic)"/>
     <param name="mapping_mode" value="$(arg mapping_mode)"/>
-    <param name="joint_pairing_reference" value="$(arg joint_pairing_reference)"/>
+    <param name="mapping_reference" value="$(arg mapping_reference)"/>
     <param name="joint_pairing_scale" value="$(arg joint_pairing_scale)"/>
     <param name="elbow_source_joint" value="$(arg elbow_source_joint)"/>
     <param name="elbow_target_joint" value="$(arg elbow_target_joint)"/>

--- a/robots/dracomancer/scripts/control/control_joint_angle.py
+++ b/robots/dracomancer/scripts/control/control_joint_angle.py
@@ -35,18 +35,27 @@ class ControlJoints:
         self.startup_pose = rospy.get_param("~startup_pose", [0.0, np.pi / 2.0, 0.0, np.pi / 2.0, 0.0, np.pi / 2.0])
         self.safe_pose = rospy.get_param("~safe_pose", self.startup_pose)
 
-        # Mapping strategy: "joint_pairing" (medium-term, default), "geometric"
-        # (long-term, FK + plane projection), or "elbow_only" (single-DOF curl driven
-        # by the elbow alone). See README.md.
-        self.mapping_mode = str(rospy.get_param("~mapping_mode", "joint_pairing")).lower()
+        # Mapping strategy: "elbow_only" (default, single-DOF: the elbow drives only
+        # DRAGON's middle joint, every other joint held unchanged), "joint_pairing"
+        # (medium-term), or "geometric" (long-term, FK + plane projection). See README.md.
+        self.mapping_mode = str(rospy.get_param("~mapping_mode", "elbow_only")).lower()
         if self.mapping_mode not in ("joint_pairing", "geometric", "elbow_only"):
             rospy.logwarn("unknown mapping_mode '%s', fall back to 'joint_pairing'", self.mapping_mode)
             self.mapping_mode = "joint_pairing"
-        self.joint_pairing_reference = str(rospy.get_param("~joint_pairing_reference", "zero")).lower()
-        if self.joint_pairing_reference not in ("zero", "startup"):
-            rospy.logwarn("unknown joint_pairing_reference '%s', fall back to 'zero'",
-                          self.joint_pairing_reference)
-            self.joint_pairing_reference = "zero"
+        # Reference (base) pose the mapping deforms around. Shared by every mapping_mode:
+        #   straight : map around 0 rad (DRAGON straightens out).
+        #   circular : map around startup_pose (DRAGON keeps its circular takeoff shape). Default.
+        # The legacy name (joint_pairing_reference) and legacy values (zero/startup) are
+        # still accepted for backward compatibility.
+        mapping_reference = rospy.get_param(
+            "~mapping_reference", rospy.get_param("~joint_pairing_reference", "circular"))
+        self.mapping_reference = str(mapping_reference).strip().lower()
+        legacy_reference = {"zero": "straight", "startup": "circular"}
+        self.mapping_reference = legacy_reference.get(self.mapping_reference, self.mapping_reference)
+        if self.mapping_reference not in ("straight", "circular"):
+            rospy.logwarn("unknown mapping_reference '%s', fall back to 'straight'",
+                          self.mapping_reference)
+            self.mapping_reference = "straight"
 
         # --- joint_pairing (medium-term) mapping ---------------------------------
         # The three arm flexion joints share the same -X axis, so moving only them
@@ -71,17 +80,17 @@ class ControlJoints:
         base_scales = rospy.get_param("~scales", [1.0] * len(self.joint_names))
         self.scales = [float(joint_pairing_scale) * float(scale) for scale in base_scales]
         default_offsets = ([0.0] * len(self.joint_names)
-                           if self.joint_pairing_reference == "zero"
+                           if self.mapping_reference == "straight"
                            else list(self.startup_pose))
         # offset[i] is the constant value when source is empty and the additive bias
-        # otherwise. "startup" keeps mapped commands near DRAGON's circular shape.
+        # otherwise. "circular" keeps mapped commands near DRAGON's circular shape.
         self.offsets = rospy.get_param("~offsets", default_offsets)
 
         # --- elbow_only mapping --------------------------------------------------
         # Map the single Dracomancer elbow flexion angle (relative to its neutral) to
         # DRAGON's middle yaw joint only; every other joint is held at its offset
-        # (reference pose). Reuses signs/scales/offsets and joint_pairing_reference, so
-        # with reference=startup the rest of DRAGON stays circular and only the middle
+        # (reference pose). Reuses signs/scales/offsets and mapping_reference, so
+        # with mapping_reference=circular the rest of DRAGON stays circular and only the middle
         # joint bends. elbow_target_joint defaults to the middle yaw in joint_names.
         self.elbow_source_joint = rospy.get_param("~elbow_source_joint", "elbow_flexion_extension_joint")
         default_yaws = [n for n in self.joint_names if n.endswith("_yaw")]
@@ -191,8 +200,8 @@ class ControlJoints:
         rospy.loginfo("teleop_mode: %s, mode_topic: %s", self.teleop_mode, self.mode_topic)
         rospy.loginfo("device_joint_topic: %s", self.device_joint_topic)
         rospy.loginfo("command_topic: %s", self.command_topic)
-        rospy.loginfo("mapping_mode: %s, joint_pairing_reference: %s",
-                      self.mapping_mode, self.joint_pairing_reference)
+        rospy.loginfo("mapping_mode: %s, mapping_reference: %s",
+                      self.mapping_mode, self.mapping_reference)
         rospy.loginfo("joint mapping: %s",
                       ", ".join("{}<-{}".format(dst, src)
                                 for dst, src in zip(self.joint_names, self.source_joint_names)))
@@ -299,20 +308,19 @@ class ControlJoints:
 
     def elbow_only_target(self):
         # Single-DOF: the elbow flexion angle (delta from neutral) drives only DRAGON's
-        # middle yaw joint (elbow_target_joint); every other joint is held at its offset
-        # (reference pose, e.g. circular when joint_pairing_reference=startup).
+        # middle yaw joint (elbow_target_joint). Every other joint is held at its last
+        # commanded (feasible) value, so elbow_only never moves any joint but the middle
+        # one (DRAGON keeps the shape it took off / was last left in).
+        target = list(self.last_feasible_target)
         elbow = self.latest_device_joints.get(self.elbow_source_joint)
         if elbow is None:
-            return list(self.last_feasible_target)
+            return target
         neutral = self.neutral_device_joints.get(self.elbow_source_joint, 0.0)
         delta = elbow - neutral
-        target = []
         for i, name in enumerate(self.joint_names):
             if name == self.elbow_target_joint:
                 mapped = self.offsets[i] + self.signs[i] * self.scales[i] * delta
-                target.append(self.clamp(mapped))
-            else:
-                target.append(self.clamp(self.offsets[i]))
+                target[i] = self.clamp(mapped)
         return target
 
     # --- geometric (long-term) mapping --------------------------------------


### PR DESCRIPTION
## 背景・目的

- teleoperation の形状マッピングで、最小自由度の `elbow_only`（肘1自由度→DRAGON 中央関節）を標準運用にしたい。
- これまで `elbow_only` は中央以外の関節も基準姿勢へ指令していたため、テイクオフ円形形状が崩れる懸念があった。
- 共有パラメータ `joint_pairing_reference` が名前上 `joint_pairing` 専用に見え、既定が `elbow_only` でも使うため分かりにくかった。

## 修正内容（技術的）

- `mapping_mode` の既定を `joint_pairing` → `elbow_only` に変更（launch / スクリプト両方）。
- `elbow_only_target()` を変更し、`elbow_target_joint`（既定 `joint2_yaw`）以外の関節を `last_feasible_target`（直前可行値）で固定。中央以外は一切変化しない。
- `joint_pairing_reference` を `mapping_reference` に改名（全 `mapping_mode` 共通であることを明示）。
  - 旧引数名 `joint_pairing_reference`、旧値 `zero`/`startup` は後方互換で引き続き使用可（`straight`/`circular` に対応）。
- `mapping_reference` の既定を `circular`（`startup_pose` 円形基準）に変更。円形テイクオフ姿勢から中央関節だけが滑らかに変形する。

## 修正内容（簡潔）

- DRAGON の遠隔操作で、既定が「肘で真ん中の関節だけを曲げる」モードになった。
- 真ん中以外の関節は動かず、離陸時の円い形を保つ。
- 設定項目の名前を分かりやすくした（古い名前もそのまま使える）。

## 確認事項

- `python3 -m py_compile` で構文チェック通過。
- launch 引数の後方互換（`joint_pairing_reference` → `mapping_reference` への自動フォールバック）を XML 上で確認。
- スクリプト内で旧パラメータ・旧値（`zero`/`startup`）を受理することをコード上で確認。
- README.md / AGENTS.md の該当記述（既定値・マッピング説明・パラメータ表）を更新。

## 未確認事項

- 実機／シミュレータでの動作確認は未実施（ROS ノード起動には DRAGON 一式が必要）。
- teleoperation 切替時、中央関節が中立角から動き出す際の `max_step` ランプ挙動の実機確認。

## 補足

- 中央以外を固定する仕様により、`mapping_reference` の `straight`/`circular` は中央関節の出発点のみに影響する。